### PR TITLE
Rev  patch 1

### DIFF
--- a/src/rulesets/GameFlag.cpp
+++ b/src/rulesets/GameFlag.cpp
@@ -309,7 +309,7 @@ static const DirectRadioRule directRadioRules[] = {
 // ---- ReplyRadioRule handlers ----
 static void onReplyTaken(const RadioPacket&, const RadioPacket&,
                          LightAir_DisplayCtrl&, GameOutput& out) {
-    out.ui.trigger(LightAir_UICtrl::UIEvent::Lit);
+    out.ui.trigger(LightAir_UICtrl::UIEvent::Taken);
 }
 static void onReplyShone(const RadioPacket&, const RadioPacket&,
                          LightAir_DisplayCtrl&, GameOutput& out) {

--- a/src/rulesets/GameFlag.cpp
+++ b/src/rulesets/GameFlag.cpp
@@ -188,14 +188,6 @@ static const LightAir_UICtrl::UIAction kFlagCarryBg = {
     /* priority     */ 1,
 };
 
-// ---- Friendly-fire feedback (UIEvent::Custom1) ----
-static const LightAir_UICtrl::UIAction kFriendlyFireAction = {
-    { 200, 0, 0, 0 }, 1,
-    { 200, 0, 0, 0 }, { 60, 0, 0, 0 },
-    { {255, 100, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0} },
-    3,
-};
-
 // ---- Helpers ----
 static uint8_t enemyTeam()            { return myTeam ^ 1; }
 
@@ -231,8 +223,6 @@ static void onBegin(LightAir_DisplayCtrl&, LightAir_Radio& radio, LightAir_UICtr
         baseO_ids[i] = runner.totemIdForRole(TotemRoleId::BASE_O, i);
         baseX_ids[i] = runner.totemIdForRole(TotemRoleId::BASE_X, i);
     }
-
-    if (ui) ui->defineCustomAction(LightAir_UICtrl::UIEvent::Custom1, kFriendlyFireAction);
 }
 
 // ---- DirectRadioRule conditions ----
@@ -328,7 +318,7 @@ static void onReplyShone(const RadioPacket&, const RadioPacket&,
 }
 static void onReplyFriend(const RadioPacket&, const RadioPacket&,
                           LightAir_DisplayCtrl&, GameOutput& out) {
-    out.ui.trigger(LightAir_UICtrl::UIEvent::Custom1);
+    out.ui.trigger(LightAir_UICtrl::UIEvent::Friend);
 }
 
 static const ReplyRadioRule replyRadioRules[] = {

--- a/src/rulesets/GameFreeForAll.cpp
+++ b/src/rulesets/GameFreeForAll.cpp
@@ -123,7 +123,7 @@ static const DirectRadioRule directRadioRules[] = {
 
 static void onReplyTaken(const RadioPacket&, const RadioPacket&,
                          LightAir_DisplayCtrl&, GameOutput& out) {
-    out.ui.trigger(LightAir_UICtrl::UIEvent::Lit);
+    out.ui.trigger(LightAir_UICtrl::UIEvent::Taken);
 }
 
 static void onReplyShone(const RadioPacket&, const RadioPacket&,

--- a/src/rulesets/GameKingOfHill.cpp
+++ b/src/rulesets/GameKingOfHill.cpp
@@ -216,7 +216,7 @@ static const DirectRadioRule directRadioRules[] = {
 // ---- ReplyRadioRule handlers ----
 static void onReplyTaken(const RadioPacket&, const RadioPacket&,
                          LightAir_DisplayCtrl&, GameOutput& out) {
-    out.ui.trigger(LightAir_UICtrl::UIEvent::Lit);
+    out.ui.trigger(LightAir_UICtrl::UIEvent::Taken);
 }
 static void onReplyShone(const RadioPacket&, const RadioPacket&,
                          LightAir_DisplayCtrl&, GameOutput& out) {

--- a/src/rulesets/GameOutflow.cpp
+++ b/src/rulesets/GameOutflow.cpp
@@ -146,16 +146,11 @@ static void onReplyShone(const RadioPacket&, const RadioPacket&,
     energy += startEnergy;   // uncapped reward for eliminating another player
     out.ui.trigger(LightAir_UICtrl::UIEvent::Lit);
 }
-static void onReplyAlreadyDown(const RadioPacket&, const RadioPacket&,
-                         LightAir_DisplayCtrl&, GameOutput& out) {
-    out.ui.trigger(LightAir_UICtrl::UIEvent::AlreadyDown);
-}
 
 static const ReplyRadioRule replyRadioRules[] = {
     //  activeInStateMask               eventType                       subType       condition  onReply
     { (1u<<IN_GAME)|(1u<<OUT_GAME), RadioEventType::ReplyReceived, REPLY_TAKEN, nullptr, onReplyTaken },
     { (1u<<IN_GAME)|(1u<<OUT_GAME), RadioEventType::ReplyReceived, REPLY_SHONE, nullptr, onReplyShone },
-    { (1u<<IN_GAME)|(1u<<OUT_GAME), RadioEventType::ReplyReceived, REPLY_SHONE, nullptr, onReplyAlreadyDown },
 };
 
 // ---- Winner election rules ----

--- a/src/rulesets/GameOutflow.cpp
+++ b/src/rulesets/GameOutflow.cpp
@@ -139,18 +139,23 @@ static const DirectRadioRule directRadioRules[] = {
 // ---- ReplyRadioRule handlers ----
 static void onReplyTaken(const RadioPacket&, const RadioPacket&,
                          LightAir_DisplayCtrl&, GameOutput& out) {
-    out.ui.trigger(LightAir_UICtrl::UIEvent::Lit);
+    out.ui.trigger(LightAir_UICtrl::UIEvent::Taken);
 }
 static void onReplyShone(const RadioPacket&, const RadioPacket&,
                          LightAir_DisplayCtrl&, GameOutput& out) {
     energy += startEnergy;   // uncapped reward for eliminating another player
     out.ui.trigger(LightAir_UICtrl::UIEvent::Lit);
 }
+static void onReplyAlreadyDown(const RadioPacket&, const RadioPacket&,
+                         LightAir_DisplayCtrl&, GameOutput& out) {
+    out.ui.trigger(LightAir_UICtrl::UIEvent::AlreadyDown);
+}
 
 static const ReplyRadioRule replyRadioRules[] = {
     //  activeInStateMask               eventType                       subType       condition  onReply
     { (1u<<IN_GAME)|(1u<<OUT_GAME), RadioEventType::ReplyReceived, REPLY_TAKEN, nullptr, onReplyTaken },
     { (1u<<IN_GAME)|(1u<<OUT_GAME), RadioEventType::ReplyReceived, REPLY_SHONE, nullptr, onReplyShone },
+    { (1u<<IN_GAME)|(1u<<OUT_GAME), RadioEventType::ReplyReceived, REPLY_SHONE, nullptr, onReplyAlreadyDown },
 };
 
 // ---- Winner election rules ----

--- a/src/rulesets/GameTeams.cpp
+++ b/src/rulesets/GameTeams.cpp
@@ -210,7 +210,7 @@ static const DirectRadioRule directRadioRules[] = {
 // ---- ReplyRadioRule handlers ----
 static void onReplyTaken(const RadioPacket&, const RadioPacket&,
                          LightAir_DisplayCtrl&, GameOutput& out) {
-    out.ui.trigger(LightAir_UICtrl::UIEvent::Lit);
+    out.ui.trigger(LightAir_UICtrl::UIEvent::Taken);
 }
 static void onReplyShone(const RadioPacket&, const RadioPacket&,
                          LightAir_DisplayCtrl&, GameOutput& out) {

--- a/src/rulesets/GameTeams.cpp
+++ b/src/rulesets/GameTeams.cpp
@@ -153,18 +153,6 @@ static bool isMyTeammate(uint8_t senderId) {
     return teamMap[senderId] == myTeam;
 }
 
-// ---- UIAction for friendly-fire feedback (UIEvent::Custom1) ----
-static const LightAir_UICtrl::UIAction kFriendlyFireAction = {
-    /* durations     */ { 200, 0, 0, 0 },
-    /* stepCount     */ 1,
-    /* soundFreqs    */ { 200, 0, 0, 0 },
-    /* vibIntensity  */ { 60,  0, 0, 0 },
-    /* rgbColors     */ { {255, 100, 0}, {0,0,0}, {0,0,0}, {0,0,0} },
-    /* lcdText       */ "Teammate!",
-    /* lcdTotalMs    */ 800,
-    /* priority      */ 3,
-};
-
 // ---- onBegin ----
 static void onBegin(LightAir_DisplayCtrl&, LightAir_Radio& radio, LightAir_UICtrl* ui,
                     const LightAir_GameRunner& runner) {
@@ -187,8 +175,6 @@ static void onBegin(LightAir_DisplayCtrl&, LightAir_Radio& radio, LightAir_UICtr
         baseO_ids[i] = runner.totemIdForRole(TotemRoleId::BASE_O, i);
         baseX_ids[i] = runner.totemIdForRole(TotemRoleId::BASE_X, i);
     }
-
-    if (ui) ui->defineCustomAction(LightAir_UICtrl::UIEvent::Custom1, kFriendlyFireAction);
 }
 
 // ---- DirectRadioRule conditions ----
@@ -235,7 +221,7 @@ static void onReplyShone(const RadioPacket&, const RadioPacket&,
 }
 static void onReplyFriend(const RadioPacket&, const RadioPacket&,
                           LightAir_DisplayCtrl&, GameOutput& out) {
-    out.ui.trigger(LightAir_UICtrl::UIEvent::Custom1);
+    out.ui.trigger(LightAir_UICtrl::UIEvent::Friend);
 }
 
 static const ReplyRadioRule replyRadioRules[] = {

--- a/src/rulesets/GameUpkeep.cpp
+++ b/src/rulesets/GameUpkeep.cpp
@@ -274,7 +274,7 @@ static const DirectRadioRule directRadioRules[] = {
 // ---- ReplyRadioRules ----
 static void onReplyTaken(const RadioPacket&, const RadioPacket&,
                          LightAir_DisplayCtrl&, GameOutput& out) {
-    out.ui.trigger(LightAir_UICtrl::UIEvent::Lit);
+    out.ui.trigger(LightAir_UICtrl::UIEvent::Taken);
 }
 static void onReplyShone(const RadioPacket&, const RadioPacket&,
                          LightAir_DisplayCtrl&, GameOutput& out) {

--- a/src/rulesets/GameUpkeep.cpp
+++ b/src/rulesets/GameUpkeep.cpp
@@ -202,18 +202,6 @@ static void refreshScoreStr() {
     snprintf(teamScoreStr, sizeof(teamScoreStr), "%d/%d", myPts, enemyPts);
 }
 
-// ---- UIAction for friendly-fire feedback (UIEvent::Custom1) ----
-static const LightAir_UICtrl::UIAction kFriendlyFireAction = {
-    /* durations    */ { 200, 0, 0, 0 },
-    /* stepCount    */ 1,
-    /* soundFreqs   */ { 200, 0, 0, 0 },
-    /* vibIntensity */ { 60,  0, 0, 0 },
-    /* rgbColors    */ { {255, 100, 0}, {0,0,0}, {0,0,0}, {0,0,0} },
-    /* lcdText      */ "Teammate!",
-    /* lcdTotalMs   */ 800,
-    /* priority     */ 3,
-};
-
 // ---- onBegin ----
 static void onBegin(LightAir_DisplayCtrl&, LightAir_Radio& radio, LightAir_UICtrl* ui,
                     const LightAir_GameRunner& runner) {
@@ -246,8 +234,6 @@ static void onBegin(LightAir_DisplayCtrl&, LightAir_Radio& radio, LightAir_UICtr
         baseO_ids[i] = runner.totemIdForRole(TotemRoleId::BASE_O, i);
         baseX_ids[i] = runner.totemIdForRole(TotemRoleId::BASE_X, i);
     }
-
-    if (ui) ui->defineCustomAction(LightAir_UICtrl::UIEvent::Custom1, kFriendlyFireAction);
 }
 
 // ---- DirectRadioRule conditions ----
@@ -296,7 +282,7 @@ static void onReplyShone(const RadioPacket&, const RadioPacket&,
 }
 static void onReplyFriend(const RadioPacket&, const RadioPacket&,
                           LightAir_DisplayCtrl&, GameOutput& out) {
-    out.ui.trigger(LightAir_UICtrl::UIEvent::Custom1);
+    out.ui.trigger(LightAir_UICtrl::UIEvent::Friend);
 }
 
 static const ReplyRadioRule replyRadioRules[] = {


### PR DESCRIPTION
Several small changes in UI manager, the main one is UI events do not contain data for the LCD anymore. That means every UI action that requires a text to be rendered on LCD must now use:
`disp.showMessage("MESSAGE", TIME_MS);`
The main drawback is sound and vib aren't anymore in sync with LCD messages. This is considered acceptable but has to be tested for possible confusion.

Also, addition of UI events for common replies to LIT:
- Friend, meaning the LIT did not produce effects due to friendlyFire being off
- AlreadyDown, meaning the LIT player is already in OUT_GAME state

All the rulesets were fixed according to these change