### PR TITLE
Fix Enlight result dropped when trigger held across all rulesets

### DIFF
--- a/src/enlight/Enlight.cpp
+++ b/src/enlight/Enlight.cpp
@@ -237,7 +237,7 @@ bool Enlight::begin() {
  *   run()  +  poll()
  * ============================================================ */
 bool Enlight::run(uint32_t repetitions) {
-    if (_repsRemaining>0||repetitions==0) return false;
+    if (_active||repetitions==0) return false;
     _repsRemaining=repetitions;
     taskENTER_CRITICAL(&_mux);
     _complete=false;

--- a/src/rulesets/GameFlag.cpp
+++ b/src/rulesets/GameFlag.cpp
@@ -407,6 +407,12 @@ static void doInGame(const InputReport& inp, const RadioReport& radio,
     tickGameTime();
 
     // ---- Shooting / energy ----
+    EnlightResult r = enlightPtr->poll();
+    if (r.status == EnlightStatus::PLAYER_HIT) {
+        if (isOpponent(r.id) || friendlyFire)
+            out.radio.sendTo(r.id, MSG_LIT);
+    }
+
     constexpr uint8_t REPS = 4;
     bool triggerActive = false;
 
@@ -433,12 +439,6 @@ static void doInGame(const InputReport& inp, const RadioReport& radio,
             energy = startEnergy;
         else if ((millis() - releaseAt) / 1000 >= (uint32_t)rechargeSecs)
             energy = startEnergy;
-    }
-
-    EnlightResult r = enlightPtr->poll();
-    if (r.status == EnlightStatus::PLAYER_HIT) {
-        if (isOpponent(r.id) || friendlyFire)
-            out.radio.sendTo(r.id, MSG_LIT);
     }
 
     // ---- Flag pickup ----

--- a/src/rulesets/GameFreeForAll.cpp
+++ b/src/rulesets/GameFreeForAll.cpp
@@ -217,6 +217,13 @@ static void doInGame(const InputReport& inp, const RadioReport&,
                      LightAir_DisplayCtrl&, GameOutput& out) {
     tickGameTime();
 
+    // Poll Enlight; a confirmed hit sends MSG_LIT to the target.
+    // points++ is deferred to onReplyShone when the target confirms elimination.
+    EnlightResult r = enlightPtr->poll();
+    if (r.status == EnlightStatus::PLAYER_HIT)
+        out.radio.sendTo(r.id, MSG_LIT);
+    // NO_HIT / LOW_POW: missed shot — no radio message.
+
     constexpr uint8_t REPS = 4;
     bool triggerActive = false;
 
@@ -246,13 +253,6 @@ static void doInGame(const InputReport& inp, const RadioReport&,
         else if ((millis() - releaseAt)/1000 >= (uint32_t)rechargeSecs)
             energy = startEnergy;
     }
-
-    // Poll Enlight; a confirmed hit sends MSG_LIT to the target.
-    // points++ is deferred to onReplyShone when the target confirms elimination.
-    EnlightResult r = enlightPtr->poll();
-    if (r.status == EnlightStatus::PLAYER_HIT)
-        out.radio.sendTo(r.id, MSG_LIT);
-    // NO_HIT / LOW_POW: missed shot — no radio message.
 }
 
 static void doOutGame(const InputReport&, const RadioReport&,

--- a/src/rulesets/GameKingOfHill.cpp
+++ b/src/rulesets/GameKingOfHill.cpp
@@ -335,6 +335,12 @@ static void doInGame(const InputReport& inp, const RadioReport& radio,
     scanCpBeacons(radio, disp, out, true);
 
     // ---- Combat ----
+    // Poll Enlight; a confirmed hit sends MSG_LIT. No friendly-fire check needed
+    // since every player is their own team.
+    EnlightResult r = enlightPtr->poll();
+    if (r.status == EnlightStatus::PLAYER_HIT)
+        out.radio.sendTo(r.id, MSG_LIT);
+
     constexpr uint8_t REPS = 4;
     bool triggerActive = false;
 
@@ -361,12 +367,6 @@ static void doInGame(const InputReport& inp, const RadioReport& radio,
         else if ((millis() - releaseAt) / 1000 >= (uint32_t)rechargeSecs)
             energy = startEnergy;
     }
-
-    // Poll Enlight; a confirmed hit sends MSG_LIT. No friendly-fire check needed
-    // since every player is their own team.
-    EnlightResult r = enlightPtr->poll();
-    if (r.status == EnlightStatus::PLAYER_HIT)
-        out.radio.sendTo(r.id, MSG_LIT);
 }
 
 static void doOutGame(const InputReport&, const RadioReport& radio,

--- a/src/rulesets/GameOutflow.cpp
+++ b/src/rulesets/GameOutflow.cpp
@@ -259,6 +259,11 @@ static void doInGame(const InputReport& inp, const RadioReport&,
 
     constexpr uint8_t REPS = 10;
 
+    // Poll Enlight; a confirmed hit sends MSG_LIT to the target.
+    EnlightResult r = enlightPtr->poll();
+    if (r.status == EnlightStatus::PLAYER_HIT)
+        out.radio.sendTo(r.id, MSG_LIT);
+
     for (uint8_t i = 0; i < inp.buttonCount; i++) {
         if (inp.buttons[i].id != InputDefaults::TRIG_1_ID) continue;
         ButtonState s = inp.buttons[i].state;
@@ -271,11 +276,6 @@ static void doInGame(const InputReport& inp, const RadioReport&,
             }
         }
     }
-
-    // Poll Enlight; a confirmed hit sends MSG_LIT to the target.
-    EnlightResult r = enlightPtr->poll();
-    if (r.status == EnlightStatus::PLAYER_HIT)
-        out.radio.sendTo(r.id, MSG_LIT);
 
     // Set depletion flag if energy reached zero (from either active or passive drain),
     // unless a fatal hit already set pendingShone (mutually exclusive).

--- a/src/rulesets/GameTeams.cpp
+++ b/src/rulesets/GameTeams.cpp
@@ -295,6 +295,13 @@ static void doInGame(const InputReport& inp, const RadioReport&,
                      LightAir_DisplayCtrl&, GameOutput& out) {
     tickGameTime();
 
+    EnlightResult r = enlightPtr->poll();
+    if (r.status == EnlightStatus::PLAYER_HIT) {
+        // Only fire if target is an opponent (or friendly fire is enabled).
+        if (isOpponent(r.id) || friendlyFire)
+            out.radio.sendTo(r.id, MSG_LIT);
+    }
+
     constexpr uint8_t REPS = 4;
     bool triggerActive = false;
 
@@ -321,13 +328,6 @@ static void doInGame(const InputReport& inp, const RadioReport&,
             energy = startEnergy;
         else if ((millis() - releaseAt) / 1000 >= (uint32_t)rechargeSecs)
             energy = startEnergy;
-    }
-
-    EnlightResult r = enlightPtr->poll();
-    if (r.status == EnlightStatus::PLAYER_HIT) {
-        // Only fire if target is an opponent (or friendly fire is enabled).
-        if (isOpponent(r.id) || friendlyFire)
-            out.radio.sendTo(r.id, MSG_LIT);
     }
 }
 

--- a/src/rulesets/GameUpkeep.cpp
+++ b/src/rulesets/GameUpkeep.cpp
@@ -399,6 +399,12 @@ static void doInGame(const InputReport& inp, const RadioReport& radio,
     scanCpBeacons(radio, disp, out, true);
 
     // ---- Combat ----
+    EnlightResult r = enlightPtr->poll();
+    if (r.status == EnlightStatus::PLAYER_HIT) {
+        if (isOpponent(r.id) || friendlyFire)
+            out.radio.sendTo(r.id, MSG_LIT);
+    }
+
     constexpr uint8_t REPS = 4;
     bool triggerActive = false;
 
@@ -424,12 +430,6 @@ static void doInGame(const InputReport& inp, const RadioReport& radio,
             energy = startEnergy;
         else if ((millis() - releaseAt) / 1000 >= (uint32_t)rechargeSecs)
             energy = startEnergy;
-    }
-
-    EnlightResult r = enlightPtr->poll();
-    if (r.status == EnlightStatus::PLAYER_HIT) {
-        if (isOpponent(r.id) || friendlyFire)
-            out.radio.sendTo(r.id, MSG_LIT);
     }
 }
 


### PR DESCRIPTION
run() was called before poll() in every doInGame(), creating a race window: when the DMA task finished and set _complete=true, _repsRemaining had already dropped to 0, so the very next run() call passed the old guard and cleared _latestResult before poll() could read it. Only the final Enlight (after trigger release) survived the race, matching the observed symptom.

Two-layer fix:
- Enlight::run(): harden guard from (_repsRemaining>0) to (_active), which stays true until poll() consumes the result, closing the race window at the source.
- All six Game*.cpp doInGame(): move enlightPtr->poll() + sendTo() to before the trigger input loop so poll() always runs before any new run() call in the same tick, regardless of the guard logic.

https://claude.ai/code/session_012gDZnG6ZdQccfPaeBz11Vh