### PR TITLE
Add GotLit UI event to warn receiver of a non-fatal hit

### DIFF
--- a/src/rulesets/GameFlag.cpp
+++ b/src/rulesets/GameFlag.cpp
@@ -259,9 +259,10 @@ static bool flagEventScored(const RadioPacket& pkt) {
 }
 
 // ---- DirectRadioRule actions ----
-static void onLitTaken(const RadioPacket& pkt, LightAir_DisplayCtrl&, GameOutput&) {
+static void onLitTaken(const RadioPacket& pkt, LightAir_DisplayCtrl&, GameOutput& out) {
     lives--;
     if (pkt.senderId < PlayerDefs::MAX_PLAYER_ID) litAt[pkt.senderId] = millis();
+    out.ui.trigger(LightAir_UICtrl::UIEvent::GotLit);
 }
 static void onLitShone(const RadioPacket& pkt, LightAir_DisplayCtrl&, GameOutput&) {
     lives--;

--- a/src/rulesets/GameFreeForAll.cpp
+++ b/src/rulesets/GameFreeForAll.cpp
@@ -120,9 +120,10 @@ static bool litAndTaken (const RadioPacket& pkt) { return lives > 1  && notImmun
 static bool litAndShone (const RadioPacket& pkt) { return lives <= 1 && notImmune(pkt); }
 static bool litButImmune(const RadioPacket& pkt) { return !notImmune(pkt); }
 
-static void onLitTaken(const RadioPacket& pkt, LightAir_DisplayCtrl&, GameOutput&) {
+static void onLitTaken(const RadioPacket& pkt, LightAir_DisplayCtrl&, GameOutput& out) {
     lives--;
     if (pkt.senderId < PlayerDefs::MAX_PLAYER_ID) litAt[pkt.senderId] = millis();
+    out.ui.trigger(LightAir_UICtrl::UIEvent::GotLit);
 }
 static void onLitShone(const RadioPacket& pkt, LightAir_DisplayCtrl&, GameOutput&) {
     lives--;

--- a/src/rulesets/GameKingOfHill.cpp
+++ b/src/rulesets/GameKingOfHill.cpp
@@ -204,9 +204,10 @@ static bool litAndShone (const RadioPacket& pkt) { return lives <= 1 && notImmun
 static bool litButImmune(const RadioPacket& pkt) { return !notImmune(pkt); }
 
 // ---- DirectRadioRule actions ----
-static void onLitTaken(const RadioPacket& pkt, LightAir_DisplayCtrl&, GameOutput&) {
+static void onLitTaken(const RadioPacket& pkt, LightAir_DisplayCtrl&, GameOutput& out) {
     lives--;
     if (pkt.senderId < PlayerDefs::MAX_PLAYER_ID) litAt[pkt.senderId] = millis();
+    out.ui.trigger(LightAir_UICtrl::UIEvent::GotLit);
 }
 static void onLitShone(const RadioPacket& pkt, LightAir_DisplayCtrl&, GameOutput&) {
     lives--;

--- a/src/rulesets/GameOutflow.cpp
+++ b/src/rulesets/GameOutflow.cpp
@@ -120,9 +120,10 @@ static bool litAndTaken(const RadioPacket&) { return energy > hitDmg; }
 static bool litAndShone(const RadioPacket&) { return energy <= hitDmg; }
 
 // ---- DirectRadioRule actions ----
-static void onLitTaken(const RadioPacket&, LightAir_DisplayCtrl&, GameOutput&) {
+static void onLitTaken(const RadioPacket&, LightAir_DisplayCtrl&, GameOutput& out) {
     energy -= hitDmg;
     if (energy < 0) energy = 0;
+    out.ui.trigger(LightAir_UICtrl::UIEvent::GotLit);
 }
 static void onLitShone(const RadioPacket&, LightAir_DisplayCtrl&, GameOutput&) {
     energy       = 0;

--- a/src/rulesets/GameTeams.cpp
+++ b/src/rulesets/GameTeams.cpp
@@ -202,9 +202,10 @@ static bool litButImmune(const RadioPacket& pkt) {
 }
 
 // ---- DirectRadioRule actions ----
-static void onLitTaken(const RadioPacket& pkt, LightAir_DisplayCtrl&, GameOutput&) {
+static void onLitTaken(const RadioPacket& pkt, LightAir_DisplayCtrl&, GameOutput& out) {
     lives--;
     if (pkt.senderId < PlayerDefs::MAX_PLAYER_ID) litAt[pkt.senderId] = millis();
+    out.ui.trigger(LightAir_UICtrl::UIEvent::GotLit);
 }
 static void onLitShone(const RadioPacket& pkt, LightAir_DisplayCtrl&, GameOutput&) {
     lives--;

--- a/src/rulesets/GameUpkeep.cpp
+++ b/src/rulesets/GameUpkeep.cpp
@@ -261,9 +261,10 @@ static bool litButImmune(const RadioPacket& pkt) {
 }
 
 // ---- DirectRadioRule actions ----
-static void onLitTaken(const RadioPacket& pkt, LightAir_DisplayCtrl&, GameOutput&) {
+static void onLitTaken(const RadioPacket& pkt, LightAir_DisplayCtrl&, GameOutput& out) {
     lives--;
     if (pkt.senderId < PlayerDefs::MAX_PLAYER_ID) litAt[pkt.senderId] = millis();
+    out.ui.trigger(LightAir_UICtrl::UIEvent::GotLit);
 }
 static void onLitShone(const RadioPacket& pkt, LightAir_DisplayCtrl&, GameOutput&) {
     lives--;

--- a/src/ui/player/LightAir_UICtrl.cpp
+++ b/src/ui/player/LightAir_UICtrl.cpp
@@ -16,6 +16,9 @@ LightAir_UICtrl::_actionTable[(uint8_t)UIEvent::Count] = {
   // Taken
   { {75,0,0,0}, 1, {4000,0,0,0}, {200,0,0,0}, { {0,255,0},{0,0,0},{0,0,0},{0,0,0} }, 2 },
 
+  // GotLit — 2-step descending orange; receiver absorbed a hit but survived
+  { {100,100,0,0}, 2, {2800,1800,0,0}, {230,150,0,0}, { {255,100,0},{160,40,0},{0,0,0},{0,0,0} }, 2 },
+
   // Immune — 2-step descending tones; blue signals active shield
   { {150,150,0,0}, 2, {1800,1200,0,0}, {180,120,0,0}, { {0,128,255},{0,0,128},{0,0,0},{0,0,0} }, 2 },
 

--- a/src/ui/player/LightAir_UICtrl.h
+++ b/src/ui/player/LightAir_UICtrl.h
@@ -19,6 +19,7 @@ public:
     Enlight,
     Lit,
     Taken,
+    GotLit,
     Immune,
     Friend,
     AlreadyDown,


### PR DESCRIPTION
When a player absorbs a hit but survives (REPLY_TAKEN), they received no UI feedback. GotLit fills this gap: a 2-step descending orange burst (2800→1800 Hz, 230→150 vibration) distinct from the shooter's green Taken/Lit events and the receiver's red Down elimination cascade.

Added to UIEvent enum and _actionTable in LightAir_UICtrl, and triggered in onLitTaken across all six rulesets (FFA, Teams, Flag, KingOfHill, Upkeep, Outflow).