### PR TITLE
Restructured scoring and winner election

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -271,12 +271,6 @@ namespace GameDefaults {
     constexpr uint32_t TOTEM_BEACON_INTERVAL_MS = 500;  // ms between MSG_TOTEM_BEACON broadcasts
     constexpr uint8_t  MSG_END_GAME             = RadioMsg::MSG_END_GAME;
 }
-// Worst-case fused score payload: (id + MAX_WINNER_VARS × int32_t) × MAX_PLAYER_ID players.
-// Must fit in a single radio packet.
-static_assert((1u + GameDefaults::MAX_WINNER_VARS * 4u) * (PlayerDefs::MAX_PLAYER_ID - 1u)
-              <= GameDefaults::RADIO_OUT_PAYLOAD,
-              "Score payload exceeds radio MTU — reduce MAX_WINNER_VARS or MAX_PLAYER_ID");
-
 // ---------------------------------------------------------------
 // Totem identity tables
 //
@@ -334,6 +328,12 @@ namespace PlayerDefs {
         "UN6",
     };
 }
+
+// Worst-case fused score payload: (id + MAX_WINNER_VARS × int32_t) × MAX_PLAYER_ID players.
+// Must fit in a single radio packet.
+static_assert((1u + GameDefaults::MAX_WINNER_VARS * 4u) * (PlayerDefs::MAX_PLAYER_ID - 1u)
+              <= GameDefaults::RADIO_OUT_PAYLOAD,
+              "Score payload exceeds radio MTU — reduce MAX_WINNER_VARS or MAX_PLAYER_ID");
 
 // ---------------------------------------------------------------
 // Colour tables

--- a/src/config.h
+++ b/src/config.h
@@ -231,7 +231,7 @@ namespace DisplayDefaults {
     constexpr uint8_t MAX_BINDINGS      = 8;
     constexpr uint8_t SCREEN_WIDTH      = 128;
     constexpr uint8_t SCREEN_HEIGHT     = 64;
-    constexpr uint8_t TRAY_HEIGHT       = 21;
+    constexpr uint8_t TRAY_HEIGHT       = 30;
     constexpr uint8_t FONT_HEIGHT       = 10;
     // ArialMT_Plain_10 glyphs start 3 px below the cell top (font leading).
     // Add this offset when aligning icons to text rendered at the same y.
@@ -266,16 +266,16 @@ namespace GameDefaults {
     constexpr uint8_t  RADIO_REPLY_MAX   = 4;    // max queued reply messages per loop
     constexpr uint8_t  MAX_WINNER_VARS   = 2;    // max entries in a winnerVars[] table (primary + tie-breaker)
     constexpr uint32_t SCORE_RETRY_MS           = 2000; // ms between score re-broadcasts during scoringState
-    constexpr uint8_t  MAX_PARTICIPANTS         = 28;   // max roster entries (players + totems); mask must be uint32_t
+    constexpr uint32_t SCORE_TIMEOUT_MS         = 10000;// ms before winner shown despite missing scores
+    constexpr uint8_t  MAX_PARTICIPANTS         = 28;   // max entries for totems; players use MAX_PLAYER_ID
     constexpr uint32_t TOTEM_BEACON_INTERVAL_MS = 500;  // ms between MSG_TOTEM_BEACON broadcasts
     constexpr uint8_t  MSG_END_GAME             = RadioMsg::MSG_END_GAME;
 }
-// Worst-case fused score payload: 4-byte mask + MAX_PARTICIPANTS slots of MAX_WINNER_VARS × int32_t.
-// Must fit in a single radio packet.  Reduce MAX_PARTICIPANTS or MAX_WINNER_VARS if this fires.
-static_assert(4u + (uint32_t)GameDefaults::MAX_PARTICIPANTS
-                  * GameDefaults::MAX_WINNER_VARS * 4u
+// Worst-case fused score payload: (id + MAX_WINNER_VARS × int32_t) × MAX_PLAYER_ID players.
+// Must fit in a single radio packet.
+static_assert((1u + GameDefaults::MAX_WINNER_VARS * 4u) * (PlayerDefs::MAX_PLAYER_ID - 1u)
               <= GameDefaults::RADIO_OUT_PAYLOAD,
-              "Score payload exceeds radio MTU — reduce MAX_PARTICIPANTS or MAX_WINNER_VARS");
+              "Score payload exceeds radio MTU — reduce MAX_WINNER_VARS or MAX_PLAYER_ID");
 
 // ---------------------------------------------------------------
 // Totem identity tables

--- a/src/game/LightAir_Game.h
+++ b/src/game/LightAir_Game.h
@@ -25,17 +25,14 @@ enum class MenuResult : uint8_t { Confirmed, Cancelled };
 // perform custom winner computation (e.g. team aggregation)
 // instead of the default individual-player ranking.
 //
-// roster[0..rosterCount-1]  — player IDs in collection order
-// accumMask                 — bit r = slots[r] is valid
-// slots[r]                  — winnerVarCount × int32_t LE for roster[r]
-// teamMap[id]               — team index (0–7) or 0xFF (teamless) for player id (size MAX_PLAYER_ID)
-// myPlayerId                — this device's logical player ID
+// accumMask     — bit id = slots[id] is valid (player-ID-indexed, ids 1–16)
+// slots[id]     — winnerVarCount × int32_t LE for player id
+// teamMap[id]   — team index (0–7) or 0xFF (teamless) for player id (size MAX_PLAYER_ID)
+// myPlayerId    — this device's logical player ID
 // ----------------------------------------------------------------
 struct ScoreTable {
-    uint8_t          rosterCount;
-    const uint8_t*   roster;
-    uint32_t         accumMask;
-    const uint8_t  (*slots)[GameDefaults::MAX_WINNER_VARS * 4];
+    uint32_t         accumMask;          // bit id set = slots[id] valid
+    const uint8_t  (*slots)[GameDefaults::MAX_WINNER_VARS * 4];  // indexed by player ID
     uint8_t          winnerVarCount;
     const WinnerVar* winnerVars;
     const uint8_t*   teamMap;    // size PlayerDefs::MAX_PLAYER_ID

--- a/src/game/LightAir_GameRunner.cpp
+++ b/src/game/LightAir_GameRunner.cpp
@@ -145,15 +145,6 @@ void LightAir_GameRunner::update() {
         return;
     }
 
-    // ---- Score collection helpers (derived constants) ----
-    const bool     scoringEnabled = _game->winnerVars &&
-                                    _game->winnerVarCount > 0 &&
-                                    _game->scoringState != 255 &&
-                                    _rosterCount > 0;
-    const uint32_t expectedMask   = _rosterCount < 32
-                                    ? (1u << _rosterCount) - 1u
-                                    : 0xFFFFFFFFu;
-
     // Step 2a: Infrastructure intercepts — handle before DirectRadioRules.
     // Marked events are skipped by the DirectRadioRules loop below.
     bool infraHandled[RADIO_MAX_PENDING] = {};
@@ -164,7 +155,7 @@ void LightAir_GameRunner::update() {
         if (ev.type != RadioEventType::MessageReceived) continue;
         if (ev.packet.msgType != GameDefaults::MSG_END_GAME) continue;
         infraHandled[e] = true;
-        if (scoringEnabled && *_game->currentState != _game->scoringState) {
+        if (*_game->currentState != _game->scoringState) {
             *_game->currentState = _game->scoringState;
             activateStateDisplay(_game->scoringState);
             output.ui.trigger(LightAir_UICtrl::UIEvent::EndGame);
@@ -261,38 +252,34 @@ void LightAir_GameRunner::update() {
     }
 
     // After Step 2d: detect scoringState entry and kick off score collection.
-    if (scoringEnabled) {
-        uint8_t cur = *_game->currentState;
-        if (cur == _game->scoringState && !_scoreActive) {
-            _scoreActive      = true;
-            _scoreResultShown = false;
-            _scoreAccumMask   = 0;
-            _scoreSentAt      = 0;
-            memset(_scoreSlots, 0, sizeof(_scoreSlots));
+    if (*_game->currentState == _game->scoringState && !_scoreActive) {
+        _scoreActive      = true;
+        _scoreResultShown = false;
+        _scoreAccumMask   = 0;
+        _scoreSentAt      = 0;
+        memset(_scoreSlots, 0, sizeof(_scoreSlots));
 
-            // Record own scores immediately.
-            uint8_t ownIdx = _rosterCount;  // sentinel: not found
-            uint8_t myId   = _radio->playerId();
-            for (uint8_t r = 0; r < _rosterCount; r++) {
-                if (_roster[r] == myId) { ownIdx = r; break; }
-            }
-            if (ownIdx < _rosterCount) {
-                scoreFillSlot(_scoreSlots[ownIdx]);
-                _scoreAccumMask |= (1u << ownIdx);
-            }
+        // Record own scores immediately.
+        uint8_t ownIdx = _rosterCount;  // sentinel: not found
+        uint8_t myId   = _radio->playerId();
+        for (uint8_t r = 0; r < _rosterCount; r++) {
+            if (_roster[r] == myId) { ownIdx = r; break; }
+        }
+        if (ownIdx < _rosterCount) {
+            scoreFillSlot(_scoreSlots[ownIdx]);
+            _scoreAccumMask |= (1u << ownIdx);
+        }
 
-            // Flood MSG_END_GAME so devices still in a non-scoring state transition.
-            output.radio.broadcast(GameDefaults::MSG_END_GAME, nullptr, 0, 2);
-            scoreBroadcastFused(output);
-            _scoreSentAt = millis();
+        // Flood MSG_END_GAME so devices still in a non-scoring state transition.
+        output.radio.broadcast(GameDefaults::MSG_END_GAME, nullptr, 0, 2);
+        scoreBroadcastFused(output);
+        _scoreSentAt = millis();
 
-            if (_scoreAccumMask == expectedMask) {
-                scoreAnnounce();
-                _scoreResultShown = true;
-                postScoreAnnounce();
-            }
-        } else if (cur != _game->scoringState) {
-            _scoreActive = false;
+        uint32_t expectedMask = _rosterCount < 32 ? (1u << _rosterCount) - 1u : 0xFFFFFFFFu;
+        if (_scoreAccumMask == expectedMask) {
+            scoreAnnounce();
+            _scoreResultShown = true;
+            postScoreAnnounce();
         }
     }
 

--- a/src/game/LightAir_GameRunner.cpp
+++ b/src/game/LightAir_GameRunner.cpp
@@ -319,46 +319,40 @@ void LightAir_GameRunner::update() {
 void LightAir_GameRunner::scoreUpdate(const InputReport& inputs,
                                        const RadioReport& radio,
                                        GameOutput& output) {
-    const bool     scoringEnabled = _game->winnerVars &&
-                                    _game->winnerVarCount > 0 &&
-                                    _game->scoringState != 255 &&
-                                    _rosterCount > 0;
-    const uint8_t  slotSize       = scoringEnabled ? _game->winnerVarCount * 4 : 0;
-    const uint32_t expectedMask   = _rosterCount < 32
-                                    ? (1u << _rosterCount) - 1u
-                                    : 0xFFFFFFFFu;
+    const uint8_t  slotSize     = _game->winnerVarCount * 4;
+    const uint32_t expectedMask = _rosterCount < 32
+                                  ? (1u << _rosterCount) - 1u
+                                  : 0xFFFFFFFFu;
 
     // Accumulate per-player score messages.
-    if (scoringEnabled) {
-        for (uint8_t e = 0; e < radio.count; e++) {
-            const RadioEvent& ev = radio.events[e];
-            if (ev.type != RadioEventType::MessageReceived) continue;
-            if (ev.packet.msgType != _game->scoreMsgType)  continue;
+    for (uint8_t e = 0; e < radio.count; e++) {
+        const RadioEvent& ev = radio.events[e];
+        if (ev.type != RadioEventType::MessageReceived) continue;
+        if (ev.packet.msgType != _game->scoreMsgType)  continue;
 
-            uint8_t expectedLen = 4 + _rosterCount * slotSize;
-            if (ev.packet.payloadLen < expectedLen) continue;
+        uint8_t expectedLen = 4 + _rosterCount * slotSize;
+        if (ev.packet.payloadLen < expectedLen) continue;
 
-            uint32_t recvMask = 0;
-            memcpy(&recvMask, ev.packet.payload, 4);
-            uint32_t newBits = recvMask & ~_scoreAccumMask;
+        uint32_t recvMask = 0;
+        memcpy(&recvMask, ev.packet.payload, 4);
+        uint32_t newBits = recvMask & ~_scoreAccumMask;
 
-            if (newBits) {
-                for (uint8_t r = 0; r < _rosterCount; r++) {
-                    if (!(newBits & (1u << r))) continue;
-                    memcpy(_scoreSlots[r],
-                           ev.packet.payload + 4 + r * slotSize,
-                           slotSize);
-                }
-                _scoreAccumMask |= newBits;
-                scoreBroadcastFused(output);
-                _scoreSentAt = millis();
+        if (newBits) {
+            for (uint8_t r = 0; r < _rosterCount; r++) {
+                if (!(newBits & (1u << r))) continue;
+                memcpy(_scoreSlots[r],
+                       ev.packet.payload + 4 + r * slotSize,
+                       slotSize);
             }
+            _scoreAccumMask |= newBits;
+            scoreBroadcastFused(output);
+            _scoreSentAt = millis();
+        }
 
-            if (_scoreAccumMask == expectedMask && !_scoreResultShown) {
-                scoreAnnounce();
-                _scoreResultShown = true;
-                postScoreAnnounce();
-            }
+        if (_scoreAccumMask == expectedMask && !_scoreResultShown) {
+            scoreAnnounce();
+            _scoreResultShown = true;
+            postScoreAnnounce();
         }
     }
 
@@ -392,7 +386,7 @@ void LightAir_GameRunner::scoreUpdate(const InputReport& inputs,
     }
 
     // Timed retry — re-broadcast fused scores while waiting for all devices.
-    if (scoringEnabled && !_scoreResultShown &&
+    if (!_scoreResultShown &&
         _scoreSentAt != 0 &&
         millis() - _scoreSentAt >= GameDefaults::SCORE_RETRY_MS) {
         scoreBroadcastFused(output);

--- a/src/game/LightAir_GameRunner.cpp
+++ b/src/game/LightAir_GameRunner.cpp
@@ -137,15 +137,22 @@ void LightAir_GameRunner::update() {
     // ---- Step 2: LOGIC ----
     GameOutput output;
 
+    if (_scoreActive) {
+        scoreUpdate(inputs, radio, output);
+        _display->update();
+        flushOutput(output);
+        while ((millis() - loopStart) < GameDefaults::LOOP_MS) {}
+        return;
+    }
+
     // ---- Score collection helpers (derived constants) ----
-    const bool   scoringEnabled = _game->winnerVars &&
-                                  _game->winnerVarCount > 0 &&
-                                  _game->scoringState != 255 &&
-                                  _rosterCount > 0;
-    const uint8_t  slotSize     = scoringEnabled ? _game->winnerVarCount * 4 : 0;
-    const uint32_t expectedMask = _rosterCount < 32
-                                  ? (1u << _rosterCount) - 1u
-                                  : 0xFFFFFFFFu;
+    const bool     scoringEnabled = _game->winnerVars &&
+                                    _game->winnerVarCount > 0 &&
+                                    _game->scoringState != 255 &&
+                                    _rosterCount > 0;
+    const uint32_t expectedMask   = _rosterCount < 32
+                                    ? (1u << _rosterCount) - 1u
+                                    : 0xFFFFFFFFu;
 
     // Step 2a: Infrastructure intercepts — handle before DirectRadioRules.
     // Marked events are skipped by the DirectRadioRules loop below.
@@ -161,46 +168,6 @@ void LightAir_GameRunner::update() {
             *_game->currentState = _game->scoringState;
             activateStateDisplay(_game->scoringState);
             output.ui.trigger(LightAir_UICtrl::UIEvent::EndGame);
-        }
-    }
-
-    // Score messages: accumulate per-player scores while in scoringState.
-    if (scoringEnabled && _scoreActive) {
-        for (uint8_t e = 0; e < radio.count; e++) {
-            const RadioEvent& ev = radio.events[e];
-            if (ev.type != RadioEventType::MessageReceived) continue;
-            if (ev.packet.msgType != _game->scoreMsgType)  continue;
-
-            infraHandled[e] = true;
-
-            // Validate payload size.
-            uint8_t expectedLen = 4 + _rosterCount * slotSize;
-            if (ev.packet.payloadLen < expectedLen) continue;
-
-            // Extract mask and new slot data.
-            uint32_t recvMask = 0;
-            memcpy(&recvMask, ev.packet.payload, 4);
-            uint32_t newBits = recvMask & ~_scoreAccumMask;
-
-            if (newBits) {
-                for (uint8_t r = 0; r < _rosterCount; r++) {
-                    if (!(newBits & (1u << r))) continue;
-                    memcpy(_scoreSlots[r],
-                           ev.packet.payload + 4 + r * slotSize,
-                           slotSize);
-                }
-                _scoreAccumMask |= newBits;
-
-                // Re-broadcast fused payload to propagate new knowledge.
-                scoreBroadcastFused(output);
-                _scoreSentAt = millis();
-            }
-
-            if (_scoreAccumMask == expectedMask && !_scoreResultShown) {
-                scoreAnnounce();
-                _scoreResultShown = true;
-                postScoreAnnounce();
-            }
         }
     }
 
@@ -238,7 +205,7 @@ void LightAir_GameRunner::update() {
     }
 
     // Step 2b: DirectRadioRules — handle all incoming MessageReceived events.
-    // Events intercepted above (MSG_END_GAME, score messages) are skipped.
+    // Events intercepted above (MSG_END_GAME, MSG_TOTEM_BEACON) are skipped.
     for (uint8_t e = 0; e < radio.count; e++) {
         const RadioEvent& ev = radio.events[e];
         if (ev.type != RadioEventType::MessageReceived) continue;
@@ -337,17 +304,100 @@ void LightAir_GameRunner::update() {
         break;
     }
 
-    // After Step 2e: timed retry — re-broadcast fused scores while waiting.
-    if (scoringEnabled && _scoreActive && !_scoreResultShown &&
+    // ---- Step 3: OUTPUT ----
+    _display->update();
+    flushOutput(output);
+
+    // Enforce fixed loop duration.
+    while ((millis() - loopStart) < GameDefaults::LOOP_MS) {}
+}
+
+/* =========================================================
+ *   SCORE UPDATE — ongoing scoring phase (runs when _scoreActive)
+ * ========================================================= */
+
+void LightAir_GameRunner::scoreUpdate(const InputReport& inputs,
+                                       const RadioReport& radio,
+                                       GameOutput& output) {
+    const bool     scoringEnabled = _game->winnerVars &&
+                                    _game->winnerVarCount > 0 &&
+                                    _game->scoringState != 255 &&
+                                    _rosterCount > 0;
+    const uint8_t  slotSize       = scoringEnabled ? _game->winnerVarCount * 4 : 0;
+    const uint32_t expectedMask   = _rosterCount < 32
+                                    ? (1u << _rosterCount) - 1u
+                                    : 0xFFFFFFFFu;
+
+    // Accumulate per-player score messages.
+    if (scoringEnabled) {
+        for (uint8_t e = 0; e < radio.count; e++) {
+            const RadioEvent& ev = radio.events[e];
+            if (ev.type != RadioEventType::MessageReceived) continue;
+            if (ev.packet.msgType != _game->scoreMsgType)  continue;
+
+            uint8_t expectedLen = 4 + _rosterCount * slotSize;
+            if (ev.packet.payloadLen < expectedLen) continue;
+
+            uint32_t recvMask = 0;
+            memcpy(&recvMask, ev.packet.payload, 4);
+            uint32_t newBits = recvMask & ~_scoreAccumMask;
+
+            if (newBits) {
+                for (uint8_t r = 0; r < _rosterCount; r++) {
+                    if (!(newBits & (1u << r))) continue;
+                    memcpy(_scoreSlots[r],
+                           ev.packet.payload + 4 + r * slotSize,
+                           slotSize);
+                }
+                _scoreAccumMask |= newBits;
+                scoreBroadcastFused(output);
+                _scoreSentAt = millis();
+            }
+
+            if (_scoreAccumMask == expectedMask && !_scoreResultShown) {
+                scoreAnnounce();
+                _scoreResultShown = true;
+                postScoreAnnounce();
+            }
+        }
+    }
+
+    // MSG_TOTEM_BEACON: no DirectRadioRules run in scoring phase; reply directly.
+    for (uint8_t e = 0; e < radio.count; e++) {
+        const RadioEvent& ev = radio.events[e];
+        if (ev.type           != RadioEventType::MessageReceived) continue;
+        if (ev.packet.msgType != RadioMsg::MSG_TOTEM_BEACON)      continue;
+
+        uint8_t id = ev.packet.senderId;
+        if (!TotemDefs::isTotemId(id)) continue;
+
+        for (uint8_t t = 0; t < _totemCount; t++) {
+            if (_totems[t].id != id) continue;
+            uint8_t roleId = _totems[t].roleId;
+            uint8_t buf[2] = { roleId, 0 };
+            uint8_t bufLen = 1;
+            if (_game->totemRequirements) {
+                for (uint8_t r = 0; r < _game->totemRequirementCount; r++) {
+                    const LightAir_TotemRequirement& req = _game->totemRequirements[r];
+                    if (req.roleId == roleId && req.configSecs != nullptr) {
+                        buf[1] = (uint8_t)*req.configSecs;
+                        bufLen = 2;
+                        break;
+                    }
+                }
+            }
+            output.radio.replyWithPayload(ev.packet, buf, bufLen);
+            break;
+        }
+    }
+
+    // Timed retry — re-broadcast fused scores while waiting for all devices.
+    if (scoringEnabled && !_scoreResultShown &&
         _scoreSentAt != 0 &&
         millis() - _scoreSentAt >= GameDefaults::SCORE_RETRY_MS) {
         scoreBroadcastFused(output);
         _scoreSentAt = millis();
     }
-
-    // ---- Step 3: OUTPUT ----
-    _display->update();
-    flushOutput(output);
 
     // A+B chord on end-game screen triggers reboot.
     if (_endExitReady) {
@@ -365,9 +415,6 @@ void LightAir_GameRunner::update() {
             esp_restart();
         }
     }
-
-    // Enforce fixed loop duration.
-    while ((millis() - loopStart) < GameDefaults::LOOP_MS) {}
 }
 
 /* =========================================================

--- a/src/game/LightAir_GameRunner.cpp
+++ b/src/game/LightAir_GameRunner.cpp
@@ -74,14 +74,12 @@ void LightAir_GameRunner::begin(const LightAir_Game& game,
  * ========================================================= */
 
 void LightAir_GameRunner::clearRoster() {
-    _rosterCount = 0;
+    _expectedPlayerMask = 0;
 }
 
 void LightAir_GameRunner::addToRoster(uint8_t id) {
-    if (_rosterCount >= GameDefaults::MAX_PARTICIPANTS) return;
-    for (uint8_t i = 0; i < _rosterCount; i++)
-        if (_roster[i] == id) return;  // ignore duplicate
-    _roster[_rosterCount++] = id;
+    if (id == 0 || id >= PlayerDefs::MAX_PLAYER_ID) return;  // totem IDs and reserved silently ignored
+    _expectedPlayerMask |= (1u << id);
 }
 
 /* =========================================================
@@ -156,9 +154,19 @@ void LightAir_GameRunner::update() {
         if (ev.packet.msgType != GameDefaults::MSG_END_GAME) continue;
         infraHandled[e] = true;
         if (*_game->currentState != _game->scoringState) {
+            uint8_t prev = *_game->currentState;
             *_game->currentState = _game->scoringState;
             activateStateDisplay(_game->scoringState);
-            output.ui.trigger(LightAir_UICtrl::UIEvent::EndGame);
+            bool fired = false;
+            for (uint8_t i = 0; i < _game->ruleCount; i++) {
+                const StateRule& r = _game->rules[i];
+                if (r.fromState == prev && r.toState == _game->scoringState) {
+                    if (r.onTransition) r.onTransition(*_display, output);
+                    fired = true;
+                    break;
+                }
+            }
+            if (!fired) output.ui.trigger(LightAir_UICtrl::UIEvent::EndGame);
         }
     }
 
@@ -255,19 +263,16 @@ void LightAir_GameRunner::update() {
     if (*_game->currentState == _game->scoringState && !_scoreActive) {
         _scoreActive      = true;
         _scoreResultShown = false;
-        _scoreAccumMask   = 0;
+        _scorePresent     = 0;
         _scoreSentAt      = 0;
+        _scoreEntryAt     = millis();
         memset(_scoreSlots, 0, sizeof(_scoreSlots));
 
         // Record own scores immediately.
-        uint8_t ownIdx = _rosterCount;  // sentinel: not found
-        uint8_t myId   = _radio->playerId();
-        for (uint8_t r = 0; r < _rosterCount; r++) {
-            if (_roster[r] == myId) { ownIdx = r; break; }
-        }
-        if (ownIdx < _rosterCount) {
-            scoreFillSlot(_scoreSlots[ownIdx]);
-            _scoreAccumMask |= (1u << ownIdx);
+        uint8_t myId = _radio->playerId();
+        if (_expectedPlayerMask & (1u << myId)) {
+            scoreFillSlot(_scoreSlots[myId]);
+            _scorePresent |= (1u << myId);
         }
 
         // Flood MSG_END_GAME so devices still in a non-scoring state transition.
@@ -275,11 +280,10 @@ void LightAir_GameRunner::update() {
         scoreBroadcastFused(output);
         _scoreSentAt = millis();
 
-        uint32_t expectedMask = _rosterCount < 32 ? (1u << _rosterCount) - 1u : 0xFFFFFFFFu;
-        if (_scoreAccumMask == expectedMask) {
-            scoreAnnounce();
+        if (_scorePresent == _expectedPlayerMask) {
             _scoreResultShown = true;
             postScoreAnnounce();
+            scoreAnnounce();
         }
     }
 
@@ -306,40 +310,35 @@ void LightAir_GameRunner::update() {
 void LightAir_GameRunner::scoreUpdate(const InputReport& inputs,
                                        const RadioReport& radio,
                                        GameOutput& output) {
-    const uint8_t  slotSize     = _game->winnerVarCount * 4;
-    const uint32_t expectedMask = _rosterCount < 32
-                                  ? (1u << _rosterCount) - 1u
-                                  : 0xFFFFFFFFu;
+    const uint8_t slotSize = _game->winnerVarCount * 4;
+    const uint8_t recSize  = 1 + slotSize;  // id byte + score data
 
     // Accumulate per-player score messages.
     for (uint8_t e = 0; e < radio.count; e++) {
         const RadioEvent& ev = radio.events[e];
         if (ev.type != RadioEventType::MessageReceived) continue;
         if (ev.packet.msgType != _game->scoreMsgType)  continue;
+        if (ev.packet.payloadLen == 0 || ev.packet.payloadLen % recSize != 0) continue;
 
-        uint8_t expectedLen = 4 + _rosterCount * slotSize;
-        if (ev.packet.payloadLen < expectedLen) continue;
-
-        uint32_t recvMask = 0;
-        memcpy(&recvMask, ev.packet.payload, 4);
-        uint32_t newBits = recvMask & ~_scoreAccumMask;
-
-        if (newBits) {
-            for (uint8_t r = 0; r < _rosterCount; r++) {
-                if (!(newBits & (1u << r))) continue;
-                memcpy(_scoreSlots[r],
-                       ev.packet.payload + 4 + r * slotSize,
-                       slotSize);
-            }
-            _scoreAccumMask |= newBits;
+        bool changed = false;
+        for (uint8_t off = 0; off + recSize <= ev.packet.payloadLen; off += recSize) {
+            uint8_t id = ev.packet.payload[off];
+            if (id == 0 || id >= PlayerDefs::MAX_PLAYER_ID) continue;
+            if (!(_expectedPlayerMask & (1u << id))) continue;
+            if (_scorePresent & (1u << id)) continue;
+            memcpy(_scoreSlots[id], ev.packet.payload + off + 1, slotSize);
+            _scorePresent |= (1u << id);
+            changed = true;
+        }
+        if (changed) {
             scoreBroadcastFused(output);
             _scoreSentAt = millis();
         }
 
-        if (_scoreAccumMask == expectedMask && !_scoreResultShown) {
-            scoreAnnounce();
+        if (_scorePresent == _expectedPlayerMask && !_scoreResultShown) {
             _scoreResultShown = true;
             postScoreAnnounce();
+            scoreAnnounce();
         }
     }
 
@@ -378,6 +377,14 @@ void LightAir_GameRunner::scoreUpdate(const InputReport& inputs,
         millis() - _scoreSentAt >= GameDefaults::SCORE_RETRY_MS) {
         scoreBroadcastFused(output);
         _scoreSentAt = millis();
+    }
+
+    // Timeout — show winner with whatever scores were collected if a device never responds.
+    if (!_scoreResultShown && _scoreEntryAt != 0 &&
+        millis() - _scoreEntryAt >= GameDefaults::SCORE_TIMEOUT_MS) {
+        _scoreResultShown = true;
+        postScoreAnnounce();
+        scoreAnnounce();
     }
 
     // A+B chord on end-game screen triggers reboot.
@@ -432,19 +439,21 @@ bool LightAir_GameRunner::scoreSlotsEqual(const uint8_t* a, const uint8_t* b) co
     return memcmp(a, b, _game->winnerVarCount * 4) == 0;
 }
 
-// Build fused payload (mask + all slots) and queue it as a broadcast.
+// Build self-describing payload ([id][data…] records) and queue as a broadcast.
 void LightAir_GameRunner::scoreBroadcastFused(GameOutput& output) const {
     uint8_t slotSize = _game->winnerVarCount * 4;
-    uint8_t totalLen = 4 + _rosterCount * slotSize;
-    if (totalLen > GameDefaults::RADIO_OUT_PAYLOAD) return;  // payload too large — skip
-
-    uint8_t buf[GameDefaults::RADIO_OUT_PAYLOAD] = {};
-    memcpy(buf, &_scoreAccumMask, 4);
-    for (uint8_t r = 0; r < _rosterCount; r++) {
-        if (_scoreAccumMask & (1u << r))
-            memcpy(buf + 4 + r * slotSize, _scoreSlots[r], slotSize);
+    uint8_t recSize  = 1 + slotSize;
+    uint8_t buf[GameDefaults::RADIO_OUT_PAYLOAD];
+    uint8_t off = 0;
+    for (uint8_t id = 1; id < PlayerDefs::MAX_PLAYER_ID; id++) {
+        if (!(_scorePresent & (1u << id))) continue;
+        if (off + recSize > GameDefaults::RADIO_OUT_PAYLOAD) break;
+        buf[off] = id;
+        memcpy(buf + off + 1, _scoreSlots[id], slotSize);
+        off += recSize;
     }
-    output.radio.broadcast(_game->scoreMsgType, buf, totalLen);
+    if (off > 0)
+        output.radio.broadcast(_game->scoreMsgType, buf, off);
 }
 
 // Find the winner from accumulated slots and call showMessage() on the display.
@@ -457,77 +466,69 @@ void LightAir_GameRunner::scoreAnnounce() const {
     // Delegate to game-specific announce if provided.
     if (_game->onScoreAnnounce) {
         ScoreTable table;
-        table.rosterCount   = _rosterCount;
-        table.roster        = _roster;
-        table.accumMask     = _scoreAccumMask;
-        table.slots         = _scoreSlots;
+        table.accumMask      = _scorePresent;
+        table.slots          = _scoreSlots;
         table.winnerVarCount = _game->winnerVarCount;
-        table.winnerVars    = _game->winnerVars;
-        table.teamMap       = _teamMap;
-        table.myPlayerId    = _radio->playerId();
+        table.winnerVars     = _game->winnerVars;
+        table.teamMap        = _teamMap;
+        table.myPlayerId     = _radio->playerId();
         _game->onScoreAnnounce(table, *_display);
         return;
     }
 
     // Default: individual-player ranking.
-    uint8_t bestIdx = 0;
-    bool    tied    = false;
+    uint8_t bestId = 0;
+    bool    tied   = false;
 
-    for (uint8_t r = 1; r < _rosterCount; r++) {
-        if (!(_scoreAccumMask & (1u << r))) continue;
-        const uint8_t* slotR    = _scoreSlots[r];
-        const uint8_t* slotBest = _scoreSlots[bestIdx];
-        if (scoreSlotBeats(slotR, slotBest)) {
-            bestIdx = r;
-            tied    = false;
-        } else if (scoreSlotsEqual(slotR, slotBest)) {
+    for (uint8_t id = 1; id < PlayerDefs::MAX_PLAYER_ID; id++) {
+        if (!(_scorePresent & (1u << id))) continue;
+        if (bestId == 0) {
+            bestId = id;
+        } else if (scoreSlotBeats(_scoreSlots[id], _scoreSlots[bestId])) {
+            bestId = id;
+            tied   = false;
+        } else if (scoreSlotsEqual(_scoreSlots[id], _scoreSlots[bestId])) {
             tied = true;
         }
     }
 
     // --- Winner / tie message ---
     char msg[32];
-    if (!tied) {
-        snprintf(msg, sizeof(msg), "%s WINS!",
-                 PlayerDefs::playerShort[_roster[bestIdx]]);
+    if (bestId == 0) {
+        snprintf(msg, sizeof(msg), "No scores!");
+    } else if (!tied) {
+        snprintf(msg, sizeof(msg), "%s WINS!", PlayerDefs::playerShort[bestId]);
     } else {
         // Collect tied participant short-names, space-separated.
-        const uint8_t* slotBest = _scoreSlots[bestIdx];
         char    names[24] = {};
         uint8_t off       = 0;
-        for (uint8_t r = 0; r < _rosterCount && off < 20; r++) {
-            if (!(_scoreAccumMask & (1u << r))) continue;
-            if (scoreSlotsEqual(_scoreSlots[r], slotBest)) {
+        for (uint8_t id = 1; id < PlayerDefs::MAX_PLAYER_ID && off < 20; id++) {
+            if (!(_scorePresent & (1u << id))) continue;
+            if (scoreSlotsEqual(_scoreSlots[id], _scoreSlots[bestId])) {
                 if (off) names[off++] = ' ';
-                memcpy(names + off, PlayerDefs::playerShort[_roster[r]], 3);
+                memcpy(names + off, PlayerDefs::playerShort[id], 3);
                 off += 3;
             }
         }
         snprintf(msg, sizeof(msg), "TIE: %s", names);
     }
 
-    // --- Own position (shown below winner; tray pushes newest msg to top) ---
-    // Show position first so it ends up on the bottom row when winner is pushed on top.
-    uint8_t myId   = _radio->playerId();
-    uint8_t mySlot = 0xFF;
-    for (uint8_t r = 0; r < _rosterCount; r++)
-        if (_roster[r] == myId) { mySlot = r; break; }
-
-    if (mySlot != 0xFF && (_scoreAccumMask & (1u << mySlot))) {
+    // --- Own position ---
+    uint8_t myId = _radio->playerId();
+    if (_scorePresent & (1u << myId)) {
         uint8_t rank = 1;
-        for (uint8_t r = 0; r < _rosterCount; r++) {
-            if (r == mySlot) continue;
-            if (!(_scoreAccumMask & (1u << r))) continue;
-            if (scoreSlotBeats(_scoreSlots[r], _scoreSlots[mySlot])) rank++;
+        for (uint8_t id = 1; id < PlayerDefs::MAX_PLAYER_ID; id++) {
+            if (id == myId || !(_scorePresent & (1u << id))) continue;
+            if (scoreSlotBeats(_scoreSlots[id], _scoreSlots[myId])) rank++;
         }
         const char* sfx = (rank == 1) ? "st" : (rank == 2) ? "nd"
                         : (rank == 3) ? "rd" : "th";
         char pos[24];
         snprintf(pos, sizeof(pos), "You arrived %u%s", rank, sfx);
-        _display->showMessage(pos, 0);   // → bottom row after winner pushed on top
+        _display->showMessage(pos, 0);
     }
 
-    _display->showMessage(msg, 0);  // → top row
+    _display->showMessage(msg, 0);
 }
 
 // Arm the A+B exit after winner announcement.

--- a/src/game/LightAir_GameRunner.h
+++ b/src/game/LightAir_GameRunner.h
@@ -26,17 +26,16 @@
 // in GameOutput::ui are silently discarded.
 //
 // Roster and totem management
-//   The roster is the ordered list of participant IDs (players and
-//   totems) expected to take part in end-game score collection.
+//   The roster registers player IDs (1–16) for end-game score collection.
+//   Totems do not contribute score data and are managed separately.
 //   Call clearRoster()/addToRoster() and clearTotems()/addTotem()
-//   from LightAir_ParticipantMenu (or directly) before begin():
+//   from LightAir_GameSetupMenu before begin():
 //
 //     runner.clearRoster();
 //     runner.clearTotems();
-//     runner.addToRoster(playerId_1);      // shooter player
+//     runner.addToRoster(playerId_1);
 //     runner.addToRoster(playerId_2);
-//     runner.addToRoster(totemId_1);       // totem (also scores)
-//     runner.addTotem(totemId_1, roleIdx); // record its role
+//     runner.addTotem(totemId_1, roleIdx);
 //     ...
 //
 // Usage:
@@ -68,10 +67,10 @@ public:
     void update();
 
     // ---- Roster management ----
-    // Call clearRoster() + addToRoster() before begin() to register all
-    // participants (players and totems) expected in end-game score collection.
+    // Call clearRoster() + addToRoster() before begin() to register all player IDs
+    // expected in end-game score collection.  Totem IDs are silently ignored.
     void clearRoster();
-    void addToRoster(uint8_t id);  // ignores duplicates; caps at MAX_PARTICIPANTS
+    void addToRoster(uint8_t id);  // accepts player IDs 1–16; ignores others
 
     // ---- Totem management ----
     // Call clearTotems() + addTotem() before begin() to record totem roles.
@@ -80,8 +79,6 @@ public:
     void addTotem(uint8_t id, uint8_t roleId);  // ignores duplicates; caps at MAX_PARTICIPANTS
 
     // Read-back accessors (for game logic or post-game queries).
-    uint8_t rosterCount()          const { return _rosterCount; }
-    uint8_t rosterId(uint8_t i)    const { return _roster[i]; }
     uint8_t totemCount()           const { return _totemCount; }
     uint8_t totemId(uint8_t i)     const { return _totems[i].id; }
     uint8_t totemRole(uint8_t i)   const { return _totems[i].roleId; }
@@ -109,9 +106,8 @@ private:
     StateBinding _bindings[DisplayDefaults::MAX_SETS];
     uint8_t      _bindingCount = 0;
 
-    // ---- Roster (players + totems for score collection) ----
-    uint8_t _roster[GameDefaults::MAX_PARTICIPANTS];
-    uint8_t _rosterCount = 0;
+    // ---- Player presence (for score collection) ----
+    uint32_t _expectedPlayerMask = 0;   // bit id = player id is in this session
 
     // ---- Totem entries (id → roleId) ----
     struct TotemEntry { uint8_t id; uint8_t roleId; };
@@ -126,9 +122,10 @@ private:
     bool     _scoreResultShown = false;   // winner display already triggered
     bool     _endExitReady     = false;   // true after scoreAnnounce; A+B triggers reboot
     uint8_t  _emptyBindingSetId = 255;    // binding set with no vars; activated after scoreAnnounce
-    uint32_t _scoreAccumMask   = 0;       // bit r set = _scoreSlots[r] is valid
+    uint32_t _scorePresent     = 0;       // bit id set = _scoreSlots[id] is valid (player-ID-indexed)
     uint32_t _scoreSentAt      = 0;       // millis() of last broadcast; 0 = not yet sent
-    uint8_t  _scoreSlots[GameDefaults::MAX_PARTICIPANTS][GameDefaults::MAX_WINNER_VARS * 4];
+    uint32_t _scoreEntryAt     = 0;       // millis() when scoring phase began (for timeout)
+    uint8_t  _scoreSlots[PlayerDefs::MAX_PLAYER_ID][GameDefaults::MAX_WINNER_VARS * 4];
 
     // ---- Helpers ----
     void activateStateDisplay(uint8_t state);

--- a/src/game/LightAir_GameRunner.h
+++ b/src/game/LightAir_GameRunner.h
@@ -133,6 +133,7 @@ private:
     // ---- Helpers ----
     void activateStateDisplay(uint8_t state);
     void flushOutput(const GameOutput& out);
+    void scoreUpdate(const InputReport&, const RadioReport&, GameOutput&);
 
     // Score collection helpers (all defined in .cpp)
     void postScoreAnnounce();

--- a/src/game/LightAir_GameSetupMenu.cpp
+++ b/src/game/LightAir_GameSetupMenu.cpp
@@ -997,7 +997,6 @@ void LightAir_GameSetupMenu::commitToRunner() {
         uint8_t roleId = _totemAssignment[s];
         if (roleId == TotemRoleId::NONE) continue;
         uint8_t id = TotemDefs::idFromIndex(s);
-        _runner.addToRoster(id);
         _runner.addTotem(id, roleId);
     }
 }

--- a/src/rulesets/GameFlag.cpp
+++ b/src/rulesets/GameFlag.cpp
@@ -550,15 +550,14 @@ static void onScoreAnnounce(const ScoreTable& t, LightAir_DisplayCtrl& disp) {
     int32_t teamPts[2]   = {0, 0};
     int32_t teamShone[2] = {0, 0};
 
-    for (uint8_t r = 0; r < t.rosterCount; r++) {
-        if (!(t.accumMask & (1u << r))) continue;
-        uint8_t pid  = t.roster[r];
-        uint8_t team = (pid < PlayerDefs::MAX_PLAYER_ID) ? t.teamMap[pid] : 0;
+    for (uint8_t pid = 1; pid < PlayerDefs::MAX_PLAYER_ID; pid++) {
+        if (!(t.accumMask & (1u << pid))) continue;
+        uint8_t team = t.teamMap[pid];
         if (team > 1) team = 0;
 
         int32_t pts = 0, shn = 0;
-        memcpy(&pts, t.slots[r],     4);  // winnerVars[0] = flagsCaptured (MAX)
-        memcpy(&shn, t.slots[r] + 4, 4);  // winnerVars[1] = shoneTimes   (MIN)
+        memcpy(&pts, t.slots[pid],     4);  // winnerVars[0] = flagsCaptured (MAX)
+        memcpy(&shn, t.slots[pid] + 4, 4);  // winnerVars[1] = shoneTimes   (MIN)
         teamPts[team]   += pts;
         teamShone[team] += shn;
     }

--- a/src/rulesets/GameTeams.cpp
+++ b/src/rulesets/GameTeams.cpp
@@ -394,15 +394,14 @@ static void onScoreAnnounce(const ScoreTable& t, LightAir_DisplayCtrl& disp) {
     int32_t teamPts[2]   = {0, 0};
     int32_t teamShone[2] = {0, 0};
 
-    for (uint8_t r = 0; r < t.rosterCount; r++) {
-        if (!(t.accumMask & (1u << r))) continue;
-        uint8_t pid  = t.roster[r];
-        uint8_t team = (pid < PlayerDefs::MAX_PLAYER_ID) ? t.teamMap[pid] : 0;
+    for (uint8_t pid = 1; pid < PlayerDefs::MAX_PLAYER_ID; pid++) {
+        if (!(t.accumMask & (1u << pid))) continue;
+        uint8_t team = t.teamMap[pid];
         if (team > 1) team = 0;
 
         int32_t pts = 0, shn = 0;
-        memcpy(&pts, t.slots[r],     4);  // winnerVars[0] = points  (MAX)
-        memcpy(&shn, t.slots[r] + 4, 4);  // winnerVars[1] = shoneTimes (MIN)
+        memcpy(&pts, t.slots[pid],     4);  // winnerVars[0] = points  (MAX)
+        memcpy(&shn, t.slots[pid] + 4, 4);  // winnerVars[1] = shoneTimes (MIN)
         teamPts[team]   += pts;
         teamShone[team] += shn;
     }

--- a/src/rulesets/GameUpkeep.cpp
+++ b/src/rulesets/GameUpkeep.cpp
@@ -496,15 +496,14 @@ static void onScoreAnnounce(const ScoreTable& t, LightAir_DisplayCtrl& disp) {
     int32_t cpPts[2] = {0, 0};
     int32_t shone[2] = {0, 0};
 
-    for (uint8_t r = 0; r < t.rosterCount; r++) {
-        if (!(t.accumMask & (1u << r))) continue;
-        uint8_t pid  = t.roster[r];
-        uint8_t team = (pid < PlayerDefs::MAX_PLAYER_ID) ? t.teamMap[pid] : 0;
+    for (uint8_t pid = 1; pid < PlayerDefs::MAX_PLAYER_ID; pid++) {
+        if (!(t.accumMask & (1u << pid))) continue;
+        uint8_t team = t.teamMap[pid];
         if (team > 1) team = 0;
 
         int32_t cp = 0, shn = 0;
-        memcpy(&cp,  t.slots[r],     4);  // winnerVars[0] = myTeamCPPoints (MAX)
-        memcpy(&shn, t.slots[r] + 4, 4);  // winnerVars[1] = shoneTimes     (MIN)
+        memcpy(&cp,  t.slots[pid],     4);  // winnerVars[0] = myTeamCPPoints (MAX)
+        memcpy(&shn, t.slots[pid] + 4, 4);  // winnerVars[1] = shoneTimes     (MIN)
 
         if (cp > cpPts[team]) cpPts[team] = cp;
         shone[team] += shn;


### PR DESCRIPTION
The scoring section has been logically detached from main GameRunner update loop.
Roster was re-factored to an array indexed by id numbers.

This is basically to solve the issue of information merging during the scoring.