### PR TITLE
Fix prevState carryover on key release

### DIFF
--- a/src/game/LightAir_GameSetupMenu.cpp
+++ b/src/game/LightAir_GameSetupMenu.cpp
@@ -1077,6 +1077,11 @@ MenuKeyEvent LightAir_GameSetupMenu::waitForKey() {
             KeyState prev = gPrevKeyState[(uint8_t)ke.key];
             gPrevKeyState[(uint8_t)ke.key] = ke.state;
 
+            // Reset to OFF when released so next press is detected as new edge
+            if (ke.state == KeyState::RELEASED || ke.state == KeyState::RELEASED_HELD) {
+                gPrevKeyState[(uint8_t)ke.key] = KeyState::OFF;
+            }
+
             // Return on state transitions: OFF→PRESSED or PRESSED→HELD
             if (ke.state == KeyState::PRESSED && prev == KeyState::OFF) {
                 gLastHeldReturn[(uint8_t)ke.key] = millis();  // Reset HELD repeat timer


### PR DESCRIPTION
When a key is released (RELEASED or RELEASED_HELD), prevState was being set to the release state. Since released keys no longer appear in the next InputReport, prevState never got reset to OFF. This caused the next key press to fail edge detection (PRESSED && prev==OFF) because prev was still RELEASED_HELD.

Fix by explicitly resetting prevState to OFF immediately after a release, ensuring that the next press is detected as a new edge.

https://claude.ai/code/session_017TAoHnavCJZgYKgzE5oBvE