### PR TITLE
Change game selection menu flow: A→countdown with defaults, B→setup

### DIFF
--- a/src/game/LightAir_GameSetupMenu.cpp
+++ b/src/game/LightAir_GameSetupMenu.cpp
@@ -468,20 +468,21 @@ void LightAir_GameSetupMenu::runGameList() {
                 if (sel + 1 < _mgr.count()) { sel++; renderGameList(sel); }
                 break;
             case 'A':
-                // Start with default/current config — skip S4.
+                // Start with default/current config — go directly to countdown with defaults.
                 _game    = &_mgr.game(sel);
                 _gameIdx = sel;
                 _mgr.saveLastPlayed(sel);
                 initTotemAssignment();
-                return;
+                if (runPreStart() == MenuResult::Confirmed) return;
+                break;
             case 'B':
-                // Enter setup.
+                // Enter setup menu.
                 _game    = &_mgr.game(sel);
                 _gameIdx = sel;
                 _mgr.saveLastPlayed(sel);
                 initTotemAssignment();
                 runSetupMenu();
-                return;
+                break;
         }
     }
 }
@@ -838,6 +839,8 @@ void LightAir_GameSetupMenu::runTotemsSubmenu() {
  * ========================================================= */
 
 MenuResult LightAir_GameSetupMenu::runPreStart() {
+    resetKeyStates();  // Sync prevState with current reality to prevent carryover
+
     // Generate session token (1–255; 0 is UNSET sentinel, skip it).
     uint8_t token = 0;
     while (token == 0) token = (uint8_t)esp_random();


### PR DESCRIPTION
Previously:
- A: Started with default config (skipped setup)
- B: Entered setup menu

Now:
- A: Goes directly to countdown menu with default configuration
- B: Enters setup menu for customization

Also fix countdown menu vanishing immediately by adding resetKeyStates() at entry. The menu was using direct polling and the previous action's RELEASED state was immediately triggering a B press handler, closing the menu.

https://claude.ai/code/session_017TAoHnavCJZgYKgzE5oBvE