### PR TITLE
Fix menu exit conflict in runPreStart by resetting key states

### DIFF
--- a/src/game/LightAir_GameSetupMenu.cpp
+++ b/src/game/LightAir_GameSetupMenu.cpp
@@ -838,6 +838,8 @@ void LightAir_GameSetupMenu::runTotemsSubmenu() {
  * ========================================================= */
 
 MenuResult LightAir_GameSetupMenu::runPreStart() {
+    resetKeyStates();  // Sync prevState with current reality to prevent carryover
+
     // Generate session token (1–255; 0 is UNSET sentinel, skip it).
     uint8_t token = 0;
     while (token == 0) token = (uint8_t)esp_random();


### PR DESCRIPTION
The last menu (runPreStart for adjusting startup time) was impossible to use when entered by pressing X from the setup menu. The X key press was immediately re-read on the first input poll, causing an instant return to the previous menu.

Added resetKeyStates() call at the start of runPreStart(), matching the pattern used in other submenus (runConfigSubmenu, runTeamsSubmenu, runTotemsSubmenu). This synchronizes the key state tracker with the current input reality, preventing key carryover from the previous menu.

https://claude.ai/code/session_0153k5QrjeE6FLrNacGo3PfG