### PR TITLE
Fix menu exit triggering on lingering key release in runPreStart

### DIFF
--- a/src/game/LightAir_GameSetupMenu.cpp
+++ b/src/game/LightAir_GameSetupMenu.cpp
@@ -882,8 +882,18 @@ MenuResult LightAir_GameSetupMenu::runPreStart() {
         for (uint8_t i = 0; i < inp.keyEventCount; i++) {
             const InputReport::KeyEntry& ke = inp.keyEvents[i];
             if (ke.keypadId != _keypadId) continue;
+
+            KeyState prev = gPrevKeyState[(uint8_t)ke.key];
+            gPrevKeyState[(uint8_t)ke.key] = ke.state;
+
+            // Only handle RELEASED/RELEASED_HELD if transitioning from a held state
+            // This prevents triggering on lingering releases from before entering the menu
+            if ((ke.state == KeyState::RELEASED || ke.state == KeyState::RELEASED_HELD) &&
+                (prev != KeyState::PRESSED && prev != KeyState::HELD)) continue;
+
             if (ke.state != KeyState::RELEASED &&
                 ke.state != KeyState::RELEASED_HELD) continue;
+
             switch (ke.key) {
                 case 'A': {
                     uint8_t payload = _countdownSecs / 10;


### PR DESCRIPTION
The previous fix was incomplete. The real issue is that runPreStart uses direct input polling and only checks current state, not state transitions. When you pressed X to enter the menu, upon release it immediately exited because it detected a RELEASED state without distinguishing between:
1. The X release that just entered the menu
2. A new X press/release after the menu is displayed

Now tracks previous key states in runPreStart and only triggers RELEASED actions when transitioning from PRESSED or HELD states (a new release), not from lingering RELEASED states that existed before menu entry.

https://claude.ai/code/session_0153k5QrjeE6FLrNacGo3PfG