### PR TITLE
Fix classifier, calibrate and store rfact/bfact, calibrate and store limpow

### DIFF
--- a/src/enlight/Enlight.cpp
+++ b/src/enlight/Enlight.cpp
@@ -121,53 +121,11 @@ void Enlight::buildSintab(uint32_t phase) {
 }
 
 /* ============================================================
- *   buildGrid() + gridLookup()
- * ============================================================ */
-static void sort_unique(float* a, int& n) {
-    for (int i=1;i<n;i++){float k=a[i];int j=i-1;while(j>=0&&a[j]>k){a[j+1]=a[j];j--;}a[j+1]=k;}
-    int o=0; for(int i=0;i<n;i++) if(o==0||a[i]!=a[o-1]) a[o++]=a[i]; n=o;
-}
-static int upper_bound_f(const float* a, int n, float v) {
-    int lo=0,hi=n; while(lo<hi){int m=(lo+hi)/2; if(a[m]<=v)lo=m+1; else hi=m;} return lo;
-}
-
-void Enlight::buildGrid() {
-    memset(&_grid, 0, sizeof(_grid));
-    float xb[GRID_MAX_THRESH], yb[GRID_MAX_THRESH]; int nx=0,ny=0;
-    for (int p=1;p<CALIB_MAX_PLAYERS;p++) {
-        const float* b=colorBox::colorBox[p]; if(b[0]<=-5.0f) continue;
-        if(nx+2<=GRID_MAX_THRESH){xb[nx++]=b[1];xb[nx++]=b[0];}
-        if(ny+2<=GRID_MAX_THRESH){yb[ny++]=b[3];yb[ny++]=b[2];}
-    }
-    sort_unique(xb,nx); sort_unique(yb,ny);
-    _grid.nX=nx; _grid.nY=ny;
-    memcpy(_grid.xThresh,xb,nx*sizeof(float));
-    memcpy(_grid.yThresh,yb,ny*sizeof(float));
-    for (int p=1;p<CALIB_MAX_PLAYERS;p++) {
-        const float* b=colorBox::colorBox[p]; if(b[0]<=-5.0f) continue;
-        _grid.table[upper_bound_f(_grid.xThresh,nx,(b[0]+b[1])*0.5f)]
-                   [upper_bound_f(_grid.yThresh,ny,(b[2]+b[3])*0.5f)] = (uint8_t)p;
-    }
-    ESP_LOGI(TAG, "Grid: %d X thresholds, %d Y thresholds", nx, ny);
-}
-
-int Enlight::gridLookup(float outr, float outang) const {
-    if (_grid.nX==0||outr<_grid.xThresh[0]||outr>_grid.xThresh[_grid.nX-1]
-      ||_grid.nY==0||outang<_grid.yThresh[0]||outang>_grid.yThresh[_grid.nY-1])
-        return -1;
-    const uint8_t p = _grid.table
-        [upper_bound_f(_grid.xThresh,_grid.nX,outr)]
-        [upper_bound_f(_grid.yThresh,_grid.nY,outang)];
-    return (p>0)?(int)p:-1;
-}
-
-/* ============================================================
  *   begin()
  * ============================================================ */
 bool Enlight::begin() {
     if (!generateWaveform()) return false;
     buildSintab(_cal.phaseOff); if (!_sintab) return false;
-    buildGrid();
 
     gpio_config_t gc={};
     gc.pin_bit_mask=1ULL<<_cfg.afeOn;
@@ -255,7 +213,7 @@ bool Enlight::run() {
 }
 
 EnlightRawMeasure Enlight::rawMeasure() const {
-    return { _rout, _gout, _bout, _rnear, _gnear, _bnear, _satCount, _arrayiter };
+    return { _rout, _gout, _bout, _rnear, _gnear, _bnear, _satCount, _arrayiter, _rawsum };
 }
 
 EnlightResult Enlight::poll() {
@@ -440,7 +398,7 @@ EnlightResult Enlight::classify() {
              _rawsum, rout, gout, bout, _rnear, _gnear, _bnear,
              (unsigned long)_satCount, frac_far_q16, frac_near_q16);
 
-    if (_rawsum <= (long long)_cal.limpow) return {EnlightStatus::LOW_POW, 0};
+    if (_rawsum <= (long long)_cal.limpow * cycles) return {EnlightStatus::LOW_POW, 0};
 
     const float farSum  = (float)((rout)  + (gout)  + (bout));
     const float nearSum = (float)((_rnear) + (_gnear) + (_bnear));
@@ -454,10 +412,13 @@ EnlightResult Enlight::classify() {
     if (s <= 0.0f) return {EnlightStatus::NO_HIT, 0};
     outr /= s; outg /= s;
     const float outang = (outr < 1.0f) ? (outg / (1.0f - outr)) : 1.0f;
-    const int hit = gridLookup(outr, outang);
-    if (hit > 0) {
-        ESP_LOGI(TAG, "HIT player %d (outr=%.3f outang=%.3f)", hit, outr, outang);
-        return {EnlightStatus::PLAYER_HIT, (uint8_t)hit};
+    for (int p = 1; p < CALIB_MAX_PLAYERS; p++) {
+        const float* b = colorBox::colorBox[p];
+        if (b[0] <= -5.0f) continue;
+        if (outr >= b[1] && outr <= b[0] && outang >= b[3] && outang <= b[2]) {
+            ESP_LOGI(TAG, "HIT player %d (outr=%.3f outang=%.3f)", p, (double)outr, (double)outang);
+            return {EnlightStatus::PLAYER_HIT, (uint8_t)p};
+        }
     }
     return {EnlightStatus::NO_HIT, 0};
 }

--- a/src/enlight/Enlight.h
+++ b/src/enlight/Enlight.h
@@ -30,8 +30,6 @@ static constexpr uint32_t GOERTZ_GRAIN = ADC_CLKS_PER_CONV * ADC_CHANNELS; // 48
 
 static constexpr float    PDM_AMPLITUDE = 0.95f;
 static constexpr int32_t  SIN_MAG       = 2048;
-static constexpr int      GRID_MAX_THRESH = CALIB_MAX_PLAYERS * 2;
-
 // Result type
 enum class EnlightStatus : uint8_t {
     IDLE        = 0,  // no run() issued since last poll()
@@ -58,14 +56,7 @@ struct EnlightRawMeasure {
     long long rnear, gnear, bnear; // near correlator sums (signed)
     uint32_t  satCount;            // saturated triples in this run
     uint32_t  totalSamples;        // total triples processed (_arrayiter)
-};
-
-// Grid classifier: O(log N) lookup in non-overlapping (outr, outang) boxes
-struct GridClassifier {
-    float   xThresh[GRID_MAX_THRESH];
-    float   yThresh[GRID_MAX_THRESH];
-    int     nX, nY;
-    uint8_t table[GRID_MAX_THRESH + 1][GRID_MAX_THRESH + 1];
+    long long rawsum;              // raw ADC sum (pre-baseline, all channels)
 };
 
 class Enlight
@@ -197,8 +188,6 @@ private:
     uint32_t    _arrayiter = 0;
     uint32_t    _satCount  = 0;
 
-    GridClassifier  _grid;
-
     // Result -- written by dmaTask (core 0), read-cleared by poll() (any core).
     portMUX_TYPE    _mux                = portMUX_INITIALIZER_UNLOCKED;
     EnlightResult   _latestResult       = {};
@@ -213,8 +202,6 @@ private:
     TaskArgs        _taskArgs      = {};
 
     bool          generateWaveform();
-    void          buildGrid();
-    int           gridLookup(float outr, float outang) const;
     void          buildAdcTxBuffer();
     void          processAdcCycle();
     EnlightResult classify();

--- a/src/enlight/EnlightCalibRoutine.cpp
+++ b/src/enlight/EnlightCalibRoutine.cpp
@@ -75,26 +75,34 @@ void EnlightCalibRoutine::step1() {
     qsort(phases, n, sizeof(uint32_t), cmp_u32);
     const uint32_t bestPhase = phases[n / 2];
 
-    // Persist and immediately apply the optimal phase offset.
+    // Compute per-channel averages; derive white-balance factors so that
+    // rfact*R = G and bfact*B = G for a spectrally-flat (Clear) target.
+    const long long avgR = sumR / n, avgG = sumG / n, avgB = sumB / n;
+    const float rfact = (avgR > 0) ? (float)avgG / (float)avgR : 1.0f;
+    const float bfact = (avgB > 0) ? (float)avgG / (float)avgB : 1.0f;
+
+    // Persist phase offset and white-balance factors; apply phase immediately.
     EnlightCalib cal;
     enlight_calib_load(cal);
     cal.phaseOff = bestPhase;
+    cal.rfact    = rfact;
+    cal.bfact    = bfact;
     enlight_calib_save(cal);
     _e.buildSintab(bestPhase);
 
     // Show results.
-    const long long avgR = sumR / n, avgG = sumG / n, avgB = sumB / n;
     const float sdR = sqrtf(fmaxf(0.f, (float)(ssR / n) - (float)(avgR * avgR)));
     const float sdG = sqrtf(fmaxf(0.f, (float)(ssG / n) - (float)(avgG * avgG)));
     const float sdB = sqrtf(fmaxf(0.f, (float)(ssB / n) - (float)(avgB * avgB)));
 
-    char l0[24], l1[24], l2[24], l3[24], l4[24];
+    char l0[24], l1[24], l2[24], l3[24], l4[24], l5[24];
     snprintf(l0, sizeof(l0), "R:%.0f G:%.0f", (double)avgR, (double)avgG);
-    snprintf(l1, sizeof(l1), "B:%.0f", (double)avgB);
+    snprintf(l1, sizeof(l1), "B:%.0f Ph:%lu", (double)avgB, (unsigned long)bestPhase);
     snprintf(l2, sizeof(l2), "sR:%.0f sG:%.0f", (double)sdR, (double)sdG);
     snprintf(l3, sizeof(l3), "sB:%.0f", (double)sdB);
-    snprintf(l4, sizeof(l4), "Phase: %lu", (unsigned long)bestPhase);
-    showLines(l0, l1, l2, l3, l4, "TRIG2: next");
+    snprintf(l4, sizeof(l4), "rfact:%.4g", (double)rfact);
+    snprintf(l5, sizeof(l5), "bfact:%.4g next", (double)bfact);
+    showLines(l0, l1, l2, l3, l4, l5);
     waitTrig(TRIG_2_ID);
 }
 
@@ -208,7 +216,7 @@ void EnlightCalibRoutine::step3() {
               "TRIG1 to start.");
     waitTrig(TRIG_1_ID);
 
-    uint32_t maxNear = 0, maxFar = 0;
+    uint32_t maxNear = 0, maxFar = 0, maxRawPerCycle = 0;
     uint32_t n = 0;
 
     while (n < N_RUNS) {
@@ -222,24 +230,32 @@ void EnlightCalibRoutine::step3() {
 
         const uint32_t nearPow = (uint32_t)(llabs(m.rnear) + llabs(m.gnear) + llabs(m.bnear));
         const uint32_t farPow  = (uint32_t)(llabs(m.rout)  + llabs(m.gout)  + llabs(m.bout));
+        // Raw sum per cycle: divide by REPS so limpow is independent of repetition count.
+        const uint32_t rawPerCycle = (m.rawsum > 0) ? (uint32_t)(m.rawsum / REPS) : 0;
 
-        if (nearPow > maxNear) maxNear = nearPow;
-        if (farPow  > maxFar)  maxFar  = farPow;
+        if (nearPow     > maxNear)         maxNear        = nearPow;
+        if (farPow      > maxFar)          maxFar         = farPow;
+        if (rawPerCycle > maxRawPerCycle)  maxRawPerCycle = rawPerCycle;
         n++;
     }
 
-    // Persist Max Near White and Max Far White.
+    // Persist Max Near White, Max Far White, and limpow.
+    // limpow is the highest per-cycle raw ADC sum seen over the white surface;
+    // classify() compares _rawsum against limpow * cycles so the threshold
+    // scales automatically with the in-game repetition count.
     EnlightCalib cal;
     enlight_calib_load(cal);
     cal.maxNearWhite = maxNear;
     cal.maxFarWhite  = maxFar;
+    cal.limpow       = maxRawPerCycle;
     enlight_calib_save(cal);
 
     // Show results.
-    char l0[24], l1[24];
+    char l0[24], l1[24], l2[24];
     snprintf(l0, sizeof(l0), "NearMax: %lu", (unsigned long)maxNear);
     snprintf(l1, sizeof(l1), "FarMax:  %lu", (unsigned long)maxFar);
-    showLines(l0, l1, nullptr, nullptr, nullptr, "TRIG2: done");
+    snprintf(l2, sizeof(l2), "limpow:  %lu", (unsigned long)maxRawPerCycle);
+    showLines(l0, l1, l2, nullptr, nullptr, "TRIG2: done");
     waitTrig(TRIG_2_ID);
 }
 

--- a/src/enlight/EnlightCalibRoutine.h
+++ b/src/enlight/EnlightCalibRoutine.h
@@ -9,7 +9,7 @@
 // Entered when 'B' is held at power-on (parallel to '^' for DM mode).
 // After completion the device proceeds with normal game setup.
 //
-// Step 1 — Phase offset (clear target in view):
+// Step 1 — Phase offset + white balance (clear target in view):
 //   For each of N_RUNS measurements the user presses TRIG1 to trigger a
 //   single Enlight run.  Runs with saturation > SAT_THRESH are discarded
 //   (user must press TRIG1 again).  For each valid run the raw ADC buffer
@@ -17,6 +17,9 @@
 //   (0°…90°); the offset yielding the maximum sum is recorded as the
 //   bestPhase for that shot.  After all shots the bestPhase values are
 //   sorted and the median is saved to NVS and applied.
+//   The average R, G, B correlator values from the clear target are also
+//   used to derive rfact = avgG/avgR and bfact = avgG/avgB, which are saved
+//   to NVS so that a spectrally-flat target normalises to equal channel weights.
 //   Press TRIG2 to continue.
 //
 // Step 2 — Baseline ("void", no target):
@@ -29,12 +32,13 @@
 //   Illuminate a white diffusing wall or target from varying distances
 //   (contact to ~5 m).  Collect 50 runs (100 ms apart, no saturation
 //   rejection).  For each reading compute:
-//     near_pow = |rnear| + |gnear| + |bnear|
-//     far_pow  = |rout|  + |gout|  + |bout|
-//   Track the maximum near_pow and maximum far_pow seen across all 50
-//   readings.  Save them to NVS as "Max Near White" and "Max Far White".
-//   These thresholds allow the classifier to distinguish reflective
-//   (legitimate) targets from diffusing surfaces.
+//     near_pow     = |rnear| + |gnear| + |bnear|
+//     far_pow      = |rout|  + |gout|  + |bout|
+//     rawPerCycle  = rawsum / REPS
+//   Track the maximum of each across all 50 readings.  Save them to NVS as
+//   "Max Near White", "Max Far White", and limpow (= max rawPerCycle).
+//   classify() rejects a measurement when rawsum <= limpow * cycles, so the
+//   threshold scales with the in-game repetition count automatically.
 //   Press TRIG2 to finish.
 // ---------------------------------------------------------------
 class EnlightCalibRoutine {


### PR DESCRIPTION
1. Replace grid-based lookup with linear scan over colorBox entries. The grid placed each color at its box center, which didn't match where actual measurements land (e.g. Red/Magenta with near-zero outang landed in empty grid cells). The linear scan checks each box boundary directly: outr in [b[1], b[0]] and outang in [b[3], b[2]]. It should be easier to check and debug, while only adding a short overhead to scan all the boxes individually instead than using a search tree (still possible in future upgrades).

2. Compute and persist rfact/bfact in step 1 of calibration. Using the average R, G, B correlator values from the Clear target, rfact = avgG/avgR and bfact = avgG/avgB are derived so that a spectrally-flat target normalises to equal channel weights. Previously these factors were never written and always stayed at 1.0 (or used previously saved rfact/bfact).

3. Set limpow in step 3 (white-wall calibration) to the maximum per-cycle rawsum observed. The limpow comparison is updated from `rawsum <= limpow` to `rawsum <= limpow * cycles` so the threshold scales correctly regardless of in-game repetition count.