### PR TITLE
Add Test mode voice to Settings menu

### DIFF
--- a/LightAir.ino
+++ b/LightAir.ino
@@ -26,6 +26,7 @@
 #endif 
 
 #include <enlight/EnlightCalibRoutine.h>
+#include <enlight/EnlightTestMode.h>
 
 // ----------------------------------------------------------------
 // Enlight global pointer
@@ -60,6 +61,7 @@ static LightAir_TotemDriver*     driver = nullptr;
 static EnlightCalib       enlightCalib;
 static Enlight*           enlight      = nullptr;
 static EnlightCalibRoutine* calibRoutine = nullptr;
+static EnlightTestMode*   testMode     = nullptr;
 
 // EnlightConfig: pin values come from player_pins.h;
 // timing/frequency constants come from EnlightDefaults (src/config.h).
@@ -173,6 +175,8 @@ void _setup() {
         enlightPtr   = enlight;
         calibRoutine = new EnlightCalibRoutine(*enlight, rawDisplay, input,
                                                InputDefaults::KEYPAD_ID);
+        testMode     = new EnlightTestMode(*enlight, rawDisplay, input,
+                                           playerUi, InputDefaults::KEYPAD_ID);
         if (!enlight->begin()) {
             Serial.println("Enlight init FAILED — halting");
             while (true) delay(1000);
@@ -206,6 +210,7 @@ void _setup() {
                                     InputDefaults::KEYPAD_ID,
                                     *radio);
         menu.setCalibRoutine(*calibRoutine);
+        menu.setTestMode(*testMode);
         if (menu.run() != MenuResult::Confirmed) {
             Log.infoln("Setup menu cancelled — rebooting");
             ESP.restart();

--- a/src/enlight/EnlightTestMode.cpp
+++ b/src/enlight/EnlightTestMode.cpp
@@ -1,0 +1,156 @@
+#include "EnlightTestMode.h"
+#include "../config.h"
+#include <Arduino.h>
+
+static const char* TAG = "TestMode";
+
+// Key state tracking for test mode input
+static KeyState gPrevKeyState[256] = {};
+static uint32_t gLastHeldReturn[256] = {};
+
+EnlightTestMode::EnlightTestMode(Enlight&            e,
+                                 LightAir_Display&   disp,
+                                 LightAir_InputCtrl& input,
+                                 LightAir_UICtrl&    uiCtrl,
+                                 uint8_t             keypadId)
+    : _e(e), _disp(disp), _input(input), _uiCtrl(uiCtrl), _keypadId(keypadId) {
+}
+
+void EnlightTestMode::run() {
+    _repetitions = 5;
+    _e.setRepetitions(_repetitions);
+    _lastHeldTime = 0;
+    memset(gPrevKeyState, 0, sizeof(gPrevKeyState));
+    memset(gLastHeldReturn, 0, sizeof(gLastHeldReturn));
+
+    bool showResult = false;
+    char resultText[32] = "";
+
+    while (true) {
+        renderDisplay(showResult, resultText);
+        showResult = false;
+
+        // Non-blocking: poll input and Enlight result
+        uint32_t now = millis();
+        const InputReport& report = _input.poll();
+
+        // Process keypad input events
+        for (uint8_t i = 0; i < report.keyEventCount; i++) {
+            const InputReport::KeyEntry& keyEvent = report.keyEvents[i];
+            if (keyEvent.keypadId != _keypadId) continue;
+
+            const KeyState state = keyEvent.state;
+            const char key = keyEvent.key;
+
+            // Update previous state for edge detection
+            KeyState prevState = gPrevKeyState[(uint8_t)key];
+            gPrevKeyState[(uint8_t)key] = state;
+
+            // A (O) = return to menu, B (X) = return to menu
+            if ((key == 'A' || key == 'B') && state == KeyState::PRESSED) {
+                return;
+            }
+
+            // < and > to adjust repetitions
+            if (key == '<' || key == '>') {
+                int8_t delta = (key == '<') ? -1 : 1;
+
+                // On PRESSED, apply once
+                if (state == KeyState::PRESSED && prevState != KeyState::PRESSED) {
+                    int32_t newVal = (int32_t)_repetitions + delta;
+                    if (newVal < 1) newVal = 100;
+                    if (newVal > 100) newVal = 1;
+                    _repetitions = (uint32_t)newVal;
+                    _e.setRepetitions(_repetitions);
+                    gLastHeldReturn[(uint8_t)key] = now;
+                }
+                // On HELD, repeat every 100ms
+                else if (state == KeyState::HELD && (now - gLastHeldReturn[(uint8_t)key] >= 100)) {
+                    int32_t newVal = (int32_t)_repetitions + delta;
+                    if (newVal < 1) newVal = 100;
+                    if (newVal > 100) newVal = 1;
+                    _repetitions = (uint32_t)newVal;
+                    _e.setRepetitions(_repetitions);
+                    gLastHeldReturn[(uint8_t)key] = now;
+                }
+            }
+        }
+
+        // Process TRIG_1 button
+        for (uint8_t i = 0; i < report.buttonCount; i++) {
+            if (report.buttons[i].id == InputDefaults::TRIG_1_ID &&
+                report.buttons[i].state == ButtonState::PRESSED) {
+                if (runEnlight()) {
+                    // A hit was detected; display result
+                    showResult = true;
+                }
+            }
+        }
+
+        // Poll Enlight for continuous measurement
+        if (_e.isActive()) {
+            EnlightResult res = _e.poll();
+            if (res.status == EnlightStatus::PLAYER_HIT) {
+                // Got a color hit
+                const char* colorName = getColorShortName(res.id);
+                snprintf(resultText, sizeof(resultText), "LIT %s", colorName);
+                showResult = true;
+                _uiCtrl.trigger(LightAir_UICtrl::UIEvent::Lit);
+            } else if (res.status == EnlightStatus::LOW_POW) {
+                snprintf(resultText, sizeof(resultText), "NO TARGET");
+                showResult = true;
+            } else if (res.status == EnlightStatus::NO_HIT) {
+                snprintf(resultText, sizeof(resultText), "NO COLOR");
+                showResult = true;
+            }
+        }
+
+        delay(10);  // Small delay to avoid spinning CPU
+    }
+}
+
+bool EnlightTestMode::runEnlight() {
+    _e.setRepetitions(_repetitions);
+    if (!_e.run()) {
+        return false;  // Already running
+    }
+
+    // Block until measurement completes
+    uint32_t timeout = millis() + 5000;
+    while (_e.isActive() && millis() < timeout) {
+        delay(10);
+    }
+
+    return true;
+}
+
+void EnlightTestMode::renderDisplay(bool showResult, const char* resultText) {
+    _disp.clear();
+    _disp.setColor(true);
+    _disp.print(0, 0, "-- Test Mode --");
+
+    char repLine[20];
+    snprintf(repLine, sizeof(repLine), "Reps: %u", (unsigned)_repetitions);
+    _disp.print(0, DisplayDefaults::FONT_HEIGHT, repLine);
+
+    if (showResult && resultText && resultText[0] != '\0') {
+        _disp.print(0, DisplayDefaults::FONT_HEIGHT * 2, resultText);
+    } else {
+        _disp.print(0, DisplayDefaults::FONT_HEIGHT * 2, "Press TRIG_1");
+    }
+
+    _disp.print(0, DisplayDefaults::FONT_HEIGHT * 3, "<  >  adjust");
+
+    char legend[30];
+    snprintf(legend, sizeof(legend), "O:Menu  X:Menu");
+    _disp.print(0, DisplayDefaults::BOTTOM_LINE_Y, legend);
+
+    _disp.flush();
+}
+
+const char* EnlightTestMode::getColorShortName(uint8_t playerId) const {
+    if (playerId < PlayerDefs::MAX_PLAYER_ID) {
+        return PlayerDefs::playerNames[playerId];
+    }
+    return "???";
+}

--- a/src/enlight/EnlightTestMode.h
+++ b/src/enlight/EnlightTestMode.h
@@ -1,0 +1,44 @@
+#pragma once
+#include "Enlight.h"
+#include "../ui/player/display/LightAir_Display.h"
+#include "../ui/player/LightAir_UICtrl.h"
+#include "../input/LightAir_InputCtrl.h"
+
+// ---------------------------------------------------------------
+// EnlightTestMode — test mode for verifying projector capability
+// without starting a game.
+//
+// Features:
+//   1. TRIG_1 press/hold calls Enlight(repetitions)
+//   2. When a player color is recognized, plays LIT event and
+//      displays the color name (e.g., "LIT RED")
+//   3. < and > keys adjust repetitions (1-100, default 5)
+//      - PRESSED: increment/decrement by 1
+//      - HELD: continuous increment/decrement
+//   4. A and B buttons return to the menu
+// ---------------------------------------------------------------
+class EnlightTestMode {
+public:
+    EnlightTestMode(Enlight&            e,
+                    LightAir_Display&   disp,
+                    LightAir_InputCtrl& input,
+                    LightAir_UICtrl&    uiCtrl,
+                    uint8_t             keypadId);
+
+    void run();  // blocking test mode loop
+
+private:
+    Enlight&            _e;
+    LightAir_Display&   _disp;
+    LightAir_InputCtrl& _input;
+    LightAir_UICtrl&    _uiCtrl;
+    uint8_t             _keypadId;
+
+    uint32_t _repetitions = 5;  // default 5, range 1-100
+    uint32_t _lastHeldTime = 0; // track timing for held key repeat
+
+    void renderDisplay(bool showResult, const char* resultText);
+    void processInput();
+    bool runEnlight();  // Returns true if a hit was detected
+    const char* getColorShortName(uint8_t playerId) const;
+};

--- a/src/game/LightAir_GameSetupMenu.cpp
+++ b/src/game/LightAir_GameSetupMenu.cpp
@@ -209,8 +209,8 @@ bool LightAir_GameSetupMenu::loadIsDm() {
 }
 
 void LightAir_GameSetupMenu::runSettingsMenu() {
-    static const char* const kEntries[] = { "Calibration", "ID / DM" };
-    static constexpr uint8_t kCount = 2;
+    static const char* const kEntries[] = { "Calibration", "ID / DM", "Test mode" };
+    static constexpr uint8_t kCount = 3;
     uint8_t sel = 0;
 
     while (true) {
@@ -236,6 +236,7 @@ void LightAir_GameSetupMenu::runSettingsMenu() {
         if (key == 'A') {
             if (sel == 0 && _calibRoutine) _calibRoutine->run();
             if (sel == 1) runIdSettings();
+            if (sel == 2 && _testMode) _testMode->run();
         }
     }
 }

--- a/src/game/LightAir_GameSetupMenu.h
+++ b/src/game/LightAir_GameSetupMenu.h
@@ -3,11 +3,13 @@
 #include "LightAir_GameRunner.h"
 #include "LightAir_GameManager.h"
 #include "../ui/player/display/LightAir_Display.h"
+#include "../ui/player/LightAir_UICtrl.h"
 #include "../input/LightAir_InputCtrl.h"
 #include "../radio/LightAir_Radio.h"
 #include "../config.h"
 
 class EnlightCalibRoutine;
+class EnlightTestMode;
 
 // ----------------------------------------------------------------
 // Config blob format (used by game_serialize_config / game_apply_config):
@@ -91,6 +93,10 @@ public:
     // Must be called before run().
     void setCalibRoutine(EnlightCalibRoutine& r) { _calibRoutine = &r; }
 
+    // Optional: register a test mode accessible from Settings → Test mode.
+    // Must be called before run().
+    void setTestMode(EnlightTestMode& t) { _testMode = &t; }
+
     // Valid after Confirmed return.
     const LightAir_Game& selectedGame() const { return *_game; }
 
@@ -104,6 +110,7 @@ private:
     uint8_t               _msgType;
 
     EnlightCalibRoutine* _calibRoutine = nullptr;
+    EnlightTestMode*     _testMode = nullptr;
     bool                 _isDm   = false;
     const LightAir_Game* _game   = nullptr;
     uint8_t              _gameIdx = 0;


### PR DESCRIPTION
Implements a third voice option in the Settings menu that allows testing projector capability without starting a game. Features:

1. TRIG_1 press/hold triggers Enlight measurements
2. Color detection displays 'LIT <COLOR>' and plays LIT event on screen
3. < and > keys adjust repetition count (1-100, default 5)
   - PRESSED: increment/decrement by 1
   - HELD: continuous increment/decrement (100ms repeat rate)
4. A and B buttons return to menu

This provides a standalone test mode for verifying the projector's color recognition capabilities