### PR TITLE
Fix Test mode selection in Settings menu

### DIFF
--- a/src/game/LightAir_GameSetupMenu.cpp
+++ b/src/game/LightAir_GameSetupMenu.cpp
@@ -246,7 +246,7 @@ void LightAir_GameSetupMenu::runSettingsMenu() {
         if (key == 'A') {
             if (sel == 0 && _calibRoutine) _calibRoutine->run();
             if (sel == 1) runIdSettings();
-            if (sel == 2 && _enlight && _uiCtrl) runTestMode();
+            if (sel == 2) runTestMode();
         }
     }
 }


### PR DESCRIPTION
Removed overly restrictive guard condition that prevented Test mode from being selected. The guard checked for both _enlight and _uiCtrl being non-null, but these are already checked inside runTestMode() itself, making the guard unnecessary and preventing access when Enlight or UICtrl pointers hadn't been set at menu construction time.