### PR TITLE
Removed enlight config as a parameter: it is now only defined in config.h

### DIFF
--- a/LightAir.ino
+++ b/LightAir.ino
@@ -63,30 +63,6 @@ static Enlight*           enlight      = nullptr;
 static EnlightCalibRoutine* calibRoutine = nullptr;
 static EnlightTestMode*   testMode     = nullptr;
 
-// EnlightConfig: pin values come from player_pins.h;
-// timing/frequency constants come from EnlightDefaults (src/config.h).
-static const EnlightConfig enlightCfg = {
-    /* adcHost     */ EnlightDefaults::ADC_HOST,
-    /* adcClk      */ PLAYER_ADC_CLK,
-    /* adcSdo      */ PLAYER_ADC_SDO,
-    /* adcSdi      */ PLAYER_ADC_SDI,
-    /* adcCs       */ PLAYER_ADC_CS,
-    /* adcClockHz  */ EnlightDefaults::ADC_CLOCK_HZ,
-    /* adcCmdR     */ EnlightDefaults::ADC_CMD_R,
-    /* adcCmdG     */ EnlightDefaults::ADC_CMD_G,
-    /* adcCmdB     */ EnlightDefaults::ADC_CMD_B,
-    /* ledHost     */ EnlightDefaults::LED_HOST,
-    /* ledSdo      */ PLAYER_LED_SDO,
-    /* ledSdiOut   */ PLAYER_LED_SDI_OUT,
-    /* ledClockHz  */ EnlightDefaults::LED_CLOCK_HZ,
-    /* ledFreqHz   */ EnlightDefaults::LED_FREQ_HZ,
-    /* pdmAmpOff   */ EnlightDefaults::PDM_AMP_OFFSET,
-    /* afeOn         */ PLAYER_AFE_ON,
-    /* taskCore      */ EnlightDefaults::TASK_CORE,
-    /* afeStartupUs  */ EnlightDefaults::AFE_STARTUP_MICROS,
-    /* satHigh       */ EnlightDefaults::SAT_HIGH,
-    /* satLow        */ EnlightDefaults::SAT_LOW,
-};
 
 // ---- Display ----
 static LightAir_SSD1306Display rawDisplay(PLAYER_I2C_SDA, PLAYER_I2C_SCL);
@@ -173,7 +149,7 @@ void _setup() {
 
         // Enlight
         enlight_calib_load(enlightCalib);
-        enlight      = new Enlight(enlightCfg, enlightCalib);
+        enlight      = new Enlight(EnlightDefaults::kConfig, enlightCalib);
         enlightPtr   = enlight;
         calibRoutine = new EnlightCalibRoutine(*enlight, rawDisplay, input,
                                                InputDefaults::KEYPAD_ID);

--- a/LightAir.ino
+++ b/LightAir.ino
@@ -149,7 +149,7 @@ void _setup() {
 
         // Enlight
         enlight_calib_load(enlightCalib);
-        enlight      = new Enlight(EnlightDefaults::kConfig, enlightCalib);
+        enlight      = new Enlight(enlightCalib);
         enlightPtr   = enlight;
         calibRoutine = new EnlightCalibRoutine(*enlight, rawDisplay, input,
                                                InputDefaults::KEYPAD_ID);

--- a/sketches/LightAir/LightAir.ino
+++ b/sketches/LightAir/LightAir.ino
@@ -63,30 +63,6 @@ static Enlight*           enlight      = nullptr;
 static EnlightCalibRoutine* calibRoutine = nullptr;
 static EnlightTestMode*   testMode     = nullptr;
 
-// EnlightConfig: pin values come from player_pins.h;
-// timing/frequency constants come from EnlightDefaults (src/config.h).
-static const EnlightConfig enlightCfg = {
-    /* adcHost     */ EnlightDefaults::ADC_HOST,
-    /* adcClk      */ PLAYER_ADC_CLK,
-    /* adcSdo      */ PLAYER_ADC_SDO,
-    /* adcSdi      */ PLAYER_ADC_SDI,
-    /* adcCs       */ PLAYER_ADC_CS,
-    /* adcClockHz  */ EnlightDefaults::ADC_CLOCK_HZ,
-    /* adcCmdR     */ EnlightDefaults::ADC_CMD_R,
-    /* adcCmdG     */ EnlightDefaults::ADC_CMD_G,
-    /* adcCmdB     */ EnlightDefaults::ADC_CMD_B,
-    /* ledHost     */ EnlightDefaults::LED_HOST,
-    /* ledSdo      */ PLAYER_LED_SDO,
-    /* ledSdiOut   */ PLAYER_LED_SDI_OUT,
-    /* ledClockHz  */ EnlightDefaults::LED_CLOCK_HZ,
-    /* ledFreqHz   */ EnlightDefaults::LED_FREQ_HZ,
-    /* pdmAmpOff   */ EnlightDefaults::PDM_AMP_OFFSET,
-    /* afeOn         */ PLAYER_AFE_ON,
-    /* taskCore      */ EnlightDefaults::TASK_CORE,
-    /* afeStartupUs  */ EnlightDefaults::AFE_STARTUP_MICROS,
-    /* satHigh       */ EnlightDefaults::SAT_HIGH,
-    /* satLow        */ EnlightDefaults::SAT_LOW,
-};
 
 // ---- Display ----
 static LightAir_SSD1306Display rawDisplay(PLAYER_I2C_SDA, PLAYER_I2C_SCL);
@@ -173,7 +149,7 @@ void _setup() {
 
         // Enlight
         enlight_calib_load(enlightCalib);
-        enlight      = new Enlight(enlightCfg, enlightCalib);
+        enlight      = new Enlight(EnlightDefaults::kConfig, enlightCalib);
         enlightPtr   = enlight;
         calibRoutine = new EnlightCalibRoutine(*enlight, rawDisplay, input,
                                                InputDefaults::KEYPAD_ID);

--- a/sketches/LightAir/LightAir.ino
+++ b/sketches/LightAir/LightAir.ino
@@ -149,7 +149,7 @@ void _setup() {
 
         // Enlight
         enlight_calib_load(enlightCalib);
-        enlight      = new Enlight(EnlightDefaults::kConfig, enlightCalib);
+        enlight      = new Enlight(enlightCalib);
         enlightPtr   = enlight;
         calibRoutine = new EnlightCalibRoutine(*enlight, rawDisplay, input,
                                                InputDefaults::KEYPAD_ID);

--- a/sketches/LightAir_EnlightTest/LightAir_EnlightTest.ino
+++ b/sketches/LightAir_EnlightTest/LightAir_EnlightTest.ino
@@ -57,9 +57,6 @@
 #define ENLIGHT_REPS  1
 // ------------------------------------------------------------------------
 
-// Saturation thresholds (must match Enlight.cpp)
-static constexpr uint16_t kSatHigh = 4085;
-static constexpr uint16_t kSatLow  = 10;
 
 // ================================================================
 // Hardware objects  (pin constants come from player_pins.h via LightAir.h)
@@ -76,29 +73,6 @@ static LightAir_InputCtrl input;
 
 static EnlightCalib  enlightCalib;
 static Enlight*      enlight = nullptr;
-
-static const EnlightConfig enlightCfg = {
-    /* adcHost     */ EnlightDefaults::ADC_HOST,
-    /* adcClk      */ EnlightDefaults::ADC_CLK,
-    /* adcSdo      */ EnlightDefaults::ADC_SDO,
-    /* adcSdi      */ EnlightDefaults::ADC_SDI,
-    /* adcCs       */ EnlightDefaults::ADC_CS,
-    /* adcClockHz  */ EnlightDefaults::ADC_CLOCK_HZ,
-    /* adcCmdR     */ EnlightDefaults::ADC_CMD_R,
-    /* adcCmdG     */ EnlightDefaults::ADC_CMD_G,
-    /* adcCmdB     */ EnlightDefaults::ADC_CMD_B,
-    /* ledHost     */ EnlightDefaults::LED_HOST,
-    /* ledSdo      */ EnlightDefaults::LED_SDO,
-    /* ledSdiOut   */ EnlightDefaults::LED_SDI_OUT,
-    /* ledClockHz  */ EnlightDefaults::LED_CLOCK_HZ,
-    /* ledFreqHz   */ EnlightDefaults::LED_FREQ_HZ,
-    /* pdmAmpOff   */ EnlightDefaults::PDM_AMP_OFFSET,
-    /* afeOn         */ EnlightDefaults::AFE_ON,
-    /* taskCore      */ EnlightDefaults::TASK_CORE,
-    /* afeStartupUs  */ EnlightDefaults::AFE_STARTUP_MICROS,
-    /* satHigh       */ EnlightDefaults::SAT_HIGH,
-    /* satLow        */ EnlightDefaults::SAT_LOW,
-};
 
 static WiFiServer tcpServer(TCP_PORT);
 static WiFiClient tcpClient;
@@ -409,9 +383,9 @@ static void takeMeasurement() {
             const uint16_t rv = adcSample(buf, base);
             const uint16_t gv = adcSample(buf, base + 1);
             const uint16_t bv = adcSample(buf, base + 2);
-            const int sat = (rv >= kSatHigh || rv <= kSatLow ||
-                             gv >= kSatHigh || gv <= kSatLow ||
-                             bv >= kSatHigh || bv <= kSatLow) ? 1 : 0;
+            const int sat = (rv >= EnlightDefaults::SAT_HIGH || rv <= EnlightDefaults::SAT_LOW ||
+                             gv >= EnlightDefaults::SAT_HIGH || gv <= EnlightDefaults::SAT_LOW ||
+                             bv >= EnlightDefaults::SAT_HIGH || bv <= EnlightDefaults::SAT_LOW) ? 1 : 0;
             const int32_t sinVal = sintab ? sintab[t % gp] : 0;
             snprintf(line, sizeof(line), "SAMPLE,%lu,%lu,%u,%u,%u,%d,%ld\n",
                      (unsigned long)ts, (unsigned long)t, rv, gv, bv, sat, (long)sinVal);
@@ -477,7 +451,7 @@ void setup() {
 
     // Enlight init
     enlight_calib_load(enlightCalib);
-    enlight = new Enlight(enlightCfg, enlightCalib);
+    enlight = new Enlight(enlightCalib);
     if (!enlight->begin()) {
         dispBegin();
         dispRow(0, "Enlight init");

--- a/src/config.h
+++ b/src/config.h
@@ -141,31 +141,6 @@ enum class DeviceHardware : uint8_t {
     TOTEM  = 1,   // static game object (base, flag, control point)
 };
 
-// ---------------------------------------------------------------
-// Enlight hardware configuration
-//
-// SDO (FSPI MOSI)             -> FAR  LED, sine   waveform, focal-point emitter.
-// SDI_out (FSPI MISO repurp.) -> NEAR LED, cosine waveform, wide-cone emitter.
-// Sine/cosine orthogonality lets a single photodiode separate both channels:
-//   correlate ADC with sintab              -> far  (rout/gout/bout)
-//   correlate ADC with sintab + _cosOffset -> near (rnear/gnear/bnear)
-// ---------------------------------------------------------------
-struct EnlightConfig {
-    uint8_t  adcHost;       // spi_host_device_t; cast when used
-    int      adcClk, adcSdo, adcSdi, adcCs;
-    uint32_t adcClockHz;
-    uint8_t  adcCmdR, adcCmdG, adcCmdB;
-    uint8_t  ledHost;       // spi_host_device_t; cast when used
-    int      ledSdo;        // sine  / FAR  LED (FSPI MOSI)
-    int      ledSdiOut;     // cosine / NEAR LED (FSPI MISO repurposed)
-    uint32_t ledClockHz, ledFreqHz;
-    float    pdmAmpOffset;  // [0.0, 0.5)
-    int      afeOn;
-    uint8_t  taskCore;
-    uint32_t afeStartupUs;  // busy-wait after AFE power-on before first DMA cycle
-    uint16_t satHigh;
-    uint16_t satLow;
-};
 
 namespace EnlightDefaults {
     constexpr uint8_t  ADC_HOST      = 1;        // SPI2_HOST
@@ -191,14 +166,6 @@ namespace EnlightDefaults {
     constexpr uint32_t AFE_STARTUP_MICROS = 2000;
     constexpr uint16_t SAT_HIGH = 4085;
     constexpr uint16_t SAT_LOW  = 10;
-
-    constexpr EnlightConfig kConfig = {
-        ADC_HOST, ADC_CLK, ADC_SDO, ADC_SDI, ADC_CS,
-        ADC_CLOCK_HZ, ADC_CMD_R, ADC_CMD_G, ADC_CMD_B,
-        LED_HOST, LED_SDO, LED_SDI_OUT, LED_CLOCK_HZ, LED_FREQ_HZ,
-        PDM_AMP_OFFSET, AFE_ON, TASK_CORE, AFE_STARTUP_MICROS,
-        SAT_HIGH, SAT_LOW,
-    };
 }
 
 // ---------------------------------------------------------------

--- a/src/config.h
+++ b/src/config.h
@@ -191,6 +191,14 @@ namespace EnlightDefaults {
     constexpr uint32_t AFE_STARTUP_MICROS = 2000;
     constexpr uint16_t SAT_HIGH = 4085;
     constexpr uint16_t SAT_LOW  = 10;
+
+    constexpr EnlightConfig kConfig = {
+        ADC_HOST, ADC_CLK, ADC_SDO, ADC_SDI, ADC_CS,
+        ADC_CLOCK_HZ, ADC_CMD_R, ADC_CMD_G, ADC_CMD_B,
+        LED_HOST, LED_SDO, LED_SDI_OUT, LED_CLOCK_HZ, LED_FREQ_HZ,
+        PDM_AMP_OFFSET, AFE_ON, TASK_CORE, AFE_STARTUP_MICROS,
+        SAT_HIGH, SAT_LOW,
+    };
 }
 
 // ---------------------------------------------------------------

--- a/src/enlight/Enlight.cpp
+++ b/src/enlight/Enlight.cpp
@@ -10,7 +10,7 @@
 
 static const char* TAG = "Enlight";
 
-Enlight::Enlight(const EnlightConfig& cfg, const EnlightCalib& cal) : _cfg(cfg), _cal(cal) {}
+Enlight::Enlight(const EnlightCalib& cal) : _cal(cal) {}
 Enlight::~Enlight() {
     heap_caps_free(_ledTxBuf);
     heap_caps_free(_adcTxBuf);
@@ -29,14 +29,14 @@ Enlight::~Enlight() {
  *   4. Fill ADC TX buffer (fixed command stream).
  * ============================================================ */
 bool Enlight::generateWaveform() {
-    if (_cfg.ledFreqHz == 0 || _cfg.ledClockHz == 0) return false;
+    if (EnlightDefaults::LED_FREQ_HZ == 0 || EnlightDefaults::LED_CLOCK_HZ == 0) return false;
 
-    const float    idealClocks = (float)_cfg.ledClockHz / (float)_cfg.ledFreqHz;
+    const float    idealClocks = (float)EnlightDefaults::LED_CLOCK_HZ / (float)EnlightDefaults::LED_FREQ_HZ;
     const uint32_t grains      = (uint32_t)fmaxf(1.0f, roundf(idealClocks / GOERTZ_GRAIN));
     _periodClocks  = grains * GOERTZ_GRAIN;
     _waveformBytes = _periodClocks / PDM_CLKS_PER_BYTE;
     _goertzPeriod  = _periodClocks / GOERTZ_GRAIN;
-    _actualFreqHz  = (float)_cfg.ledClockHz / (float)_periodClocks;
+    _actualFreqHz  = (float)EnlightDefaults::LED_CLOCK_HZ / (float)_periodClocks;
 
     _periodsPerCycle  = (uint32_t)(ENLIGHT_SPI_MAX_DMA_LEN / _waveformBytes);
     if (_periodsPerCycle == 0) {
@@ -47,13 +47,13 @@ bool Enlight::generateWaveform() {
     _adcConvsPerCycle = _periodsPerCycle * (_periodClocks / ADC_CLKS_PER_CONV);
     _adcBufBytes      = (_adcConvsPerCycle + ADC_PIPELINE_DELAY) * ADC_BYTES_PER_CONV;
 
-    const float cycleMs = (float)(_periodsPerCycle * _periodClocks) / (float)_cfg.ledClockHz * 1000.0f;
+    const float cycleMs = (float)(_periodsPerCycle * _periodClocks) / (float)EnlightDefaults::LED_CLOCK_HZ * 1000.0f;
     ESP_LOGI(TAG, "PDM: req=%.1fHz actual=%.4fHz period=%lu clocks/%lu bytes "
              "GP=%lu perCycle=%lu cycleMs=%.3f pdmOff=%.3f",
-             (double)_cfg.ledFreqHz, (double)_actualFreqHz,
+             (double)EnlightDefaults::LED_FREQ_HZ, (double)_actualFreqHz,
              (unsigned long)_periodClocks, (unsigned long)_waveformBytes,
              (unsigned long)_goertzPeriod, (unsigned long)_periodsPerCycle,
-             (double)cycleMs, (double)_cfg.pdmAmpOffset);
+             (double)cycleMs, (double)EnlightDefaults::PDM_AMP_OFFSET);
 
     _ledTxBuf = (uint8_t*)heap_caps_malloc(_ledBufBytes, MALLOC_CAP_DMA|MALLOC_CAP_INTERNAL);
     _adcTxBuf = (uint8_t*)heap_caps_malloc(_adcBufBytes, MALLOC_CAP_DMA|MALLOC_CAP_INTERNAL);
@@ -63,7 +63,7 @@ bool Enlight::generateWaveform() {
     }
     memset(_adcRxBuf, 0, _adcBufBytes);
 
-    const float base = 0.5f + _cfg.pdmAmpOffset, swing = 0.5f - _cfg.pdmAmpOffset;
+    const float base = 0.5f + EnlightDefaults::PDM_AMP_OFFSET, swing = 0.5f - EnlightDefaults::PDM_AMP_OFFSET;
     const float twoPiOverT = 2.0f * (float)M_PI / (float)_periodClocks;
     float acc_sin = 0.0f, acc_cos = 0.0f;
     for (uint32_t i = 0; i < _periodClocks; i += PDM_CLKS_PER_BYTE) {
@@ -170,33 +170,33 @@ bool Enlight::begin() {
     buildGrid();
 
     gpio_config_t gc={};
-    gc.pin_bit_mask=1ULL<<_cfg.afeOn;
+    gc.pin_bit_mask=1ULL<<EnlightDefaults::AFE_ON;
     gc.mode=GPIO_MODE_OUTPUT;
     gpio_config(&gc);
-    gpio_set_level((gpio_num_t)_cfg.afeOn, 0);
+    gpio_set_level((gpio_num_t)EnlightDefaults::AFE_ON, 0);
 
     spi_bus_config_t lb={};
-    lb.mosi_io_num=_cfg.ledSdo;
-    lb.miso_io_num=_cfg.ledSdiOut;
+    lb.mosi_io_num=EnlightDefaults::LED_SDO;
+    lb.miso_io_num=EnlightDefaults::LED_SDI_OUT;
     lb.sclk_io_num=-1;
     lb.quadwp_io_num=-1;
     lb.quadhd_io_num=-1;
     lb.max_transfer_sz=_ledBufBytes;
 
-    if (spi_bus_initialize((spi_host_device_t)_cfg.ledHost,&lb,SPI_DMA_CH_AUTO)!=ESP_OK) {
+    if (spi_bus_initialize((spi_host_device_t)EnlightDefaults::LED_HOST,&lb,SPI_DMA_CH_AUTO)!=ESP_OK) {
         ESP_LOGE(TAG,"LED bus init failed"); return false; }
     spi_device_interface_config_t ld={};
-    ld.clock_speed_hz=(int)_cfg.ledClockHz;
+    ld.clock_speed_hz=(int)EnlightDefaults::LED_CLOCK_HZ;
     ld.mode=0;
     ld.spics_io_num=-1;
     ld.queue_size=1;
     ld.flags=SPI_DEVICE_HALFDUPLEX;
 
-    if (spi_bus_add_device((spi_host_device_t)_cfg.ledHost,&ld,&_ledDevice)!=ESP_OK) {
+    if (spi_bus_add_device((spi_host_device_t)EnlightDefaults::LED_HOST,&ld,&_ledDevice)!=ESP_OK) {
         ESP_LOGE(TAG,"LED dev add failed"); return false; }
-    const int lp[2]={_cfg.ledSdo,_cfg.ledSdiOut};
-    const int ls[2]={(int)spi_periph_signal[(spi_host_device_t)_cfg.ledHost].spid_out,
-                     (int)spi_periph_signal[(spi_host_device_t)_cfg.ledHost].spiq_out};
+    const int lp[2]={EnlightDefaults::LED_SDO,EnlightDefaults::LED_SDI_OUT};
+    const int ls[2]={(int)spi_periph_signal[(spi_host_device_t)EnlightDefaults::LED_HOST].spid_out,
+                     (int)spi_periph_signal[(spi_host_device_t)EnlightDefaults::LED_HOST].spiq_out};
     for (int n=0;n<2;n++) {
         gpio_hal_iomux_func_sel(GPIO_PIN_MUX_REG[lp[n]],PIN_FUNC_GPIO);
         gpio_set_direction((gpio_num_t)lp[n],GPIO_MODE_OUTPUT);
@@ -204,18 +204,18 @@ bool Enlight::begin() {
     }
 
     spi_bus_config_t ab={};
-    ab.mosi_io_num=_cfg.adcSdo;
-    ab.miso_io_num=_cfg.adcSdi;
-    ab.sclk_io_num=_cfg.adcClk;
+    ab.mosi_io_num=EnlightDefaults::ADC_SDO;
+    ab.miso_io_num=EnlightDefaults::ADC_SDI;
+    ab.sclk_io_num=EnlightDefaults::ADC_CLK;
     ab.quadwp_io_num=-1;
     ab.quadhd_io_num=-1;
     ab.max_transfer_sz=_adcBufBytes;
 
-    if (spi_bus_initialize((spi_host_device_t)_cfg.adcHost,&ab,SPI_DMA_CH_AUTO)!=ESP_OK) {
+    if (spi_bus_initialize((spi_host_device_t)EnlightDefaults::ADC_HOST,&ab,SPI_DMA_CH_AUTO)!=ESP_OK) {
         ESP_LOGE(TAG,"ADC bus init failed"); return false; }
     spi_device_interface_config_t ad={};
-    ad.clock_speed_hz=(int)_cfg.adcClockHz; ad.mode=0; ad.spics_io_num=_cfg.adcCs; ad.queue_size=1;
-    if (spi_bus_add_device((spi_host_device_t)_cfg.adcHost,&ad,&_adcDevice)!=ESP_OK) {
+    ad.clock_speed_hz=(int)EnlightDefaults::ADC_CLOCK_HZ; ad.mode=0; ad.spics_io_num=EnlightDefaults::ADC_CS; ad.queue_size=1;
+    if (spi_bus_add_device((spi_host_device_t)EnlightDefaults::ADC_HOST,&ad,&_adcDevice)!=ESP_OK) {
         ESP_LOGE(TAG,"ADC dev add failed"); return false; }
 
     memset(&_ledTrans,0,sizeof(_ledTrans));
@@ -249,7 +249,7 @@ bool Enlight::run() {
     _resultDelivered = false;
     _active=true;
     _firstCycle=true;
-    gpio_set_level((gpio_num_t)_cfg.afeOn,1);
+    gpio_set_level((gpio_num_t)EnlightDefaults::AFE_ON,1);
     spawnCycle();
     return true;
 }
@@ -288,7 +288,7 @@ EnlightResult Enlight::poll() {
  *   buildAdcTxBuffer() -- filled once at begin()
  * ============================================================ */
 void Enlight::buildAdcTxBuffer() {
-    const uint8_t cmds[ADC_CHANNELS]={_cfg.adcCmdR,_cfg.adcCmdG,_cfg.adcCmdB};
+    const uint8_t cmds[ADC_CHANNELS]={EnlightDefaults::ADC_CMD_R,EnlightDefaults::ADC_CMD_G,EnlightDefaults::ADC_CMD_B};
     const uint32_t slots=_adcConvsPerCycle+ADC_PIPELINE_DELAY;
     for (uint32_t i=0;i<slots;i++) {
         _adcTxBuf[i*2]=(i<_adcConvsPerCycle)?cmds[i%ADC_CHANNELS]:0x00;
@@ -336,9 +336,9 @@ void Enlight::processAdcCycle() {
         const int32_t  ks  = _sintab[idx];
         const int32_t  kc  = _sintab[(idx + _cosOffset) % _goertzPeriod];
 
-        if (rv >= _cfg.satHigh || rv <= _cfg.satLow ||
-            gv >= _cfg.satHigh || gv <= _cfg.satLow ||
-            bv >= _cfg.satHigh || bv <= _cfg.satLow) {
+        if (rv >= EnlightDefaults::SAT_HIGH || rv <= EnlightDefaults::SAT_LOW ||
+            gv >= EnlightDefaults::SAT_HIGH || gv <= EnlightDefaults::SAT_LOW ||
+            bv >= EnlightDefaults::SAT_HIGH || bv <= EnlightDefaults::SAT_LOW) {
             // Record which phase bucket was lost; classify() uses this for baseline correction.
             _satPhaseCount[idx]++;
             _satCount++;
@@ -477,14 +477,14 @@ EnlightResult Enlight::classifyNear() {
 void Enlight::spawnCycle() {
     _taskArgs={this};
     xTaskCreatePinnedToCore(dmaTask,"EnlightDMA",4096,&_taskArgs,
-                            configMAX_PRIORITIES-1,&_taskHandle,_cfg.taskCore);
+                            configMAX_PRIORITIES-1,&_taskHandle,EnlightDefaults::TASK_CORE);
 }
 
 void Enlight::onCycleDone() {
     processAdcCycle();
     _repsRemaining--;
     if (_repsRemaining==0) {
-        gpio_set_level((gpio_num_t)_cfg.afeOn,0);
+        gpio_set_level((gpio_num_t)EnlightDefaults::AFE_ON,0);
         EnlightResult r=classify();
         taskENTER_CRITICAL(&_mux);
         _latestResult=r;
@@ -500,7 +500,7 @@ void Enlight::dmaTask(void* arg) {
     if (s->_firstCycle) {
         s->_firstCycle=false;
         const int64_t t0=esp_timer_get_time();
-        while (esp_timer_get_time()-t0 < (int64_t)s->_cfg.afeStartupUs) {}
+        while (esp_timer_get_time()-t0 < (int64_t)EnlightDefaults::AFE_STARTUP_MICROS) {}
     }
     spi_device_queue_trans(s->_ledDevice,&s->_ledTrans,portMAX_DELAY);
     spi_device_queue_trans(s->_adcDevice,&s->_adcTrans,portMAX_DELAY);

--- a/src/enlight/Enlight.h
+++ b/src/enlight/Enlight.h
@@ -71,7 +71,7 @@ struct GridClassifier {
 class Enlight
 {
 public:
-    Enlight(const EnlightConfig& cfg, const EnlightCalib& cal);
+    Enlight(const EnlightCalib& cal);
     ~Enlight();
 
     // One-time hardware init, waveform generation, classifier build.
@@ -141,7 +141,6 @@ public:
     void buildSintab(uint32_t phase);
 
 private:
-    EnlightConfig   _cfg;
     EnlightCalib    _cal;
 
     // Waveform / cycle geometry


### PR DESCRIPTION
Enlight constructor used a config struct as an argument. This is not wanted since the configuration should only be defined at config.h level, considering the HW and firmware version. There should be no freedom to call Enlight with different configurations, in order to prevent wrong settings or non-homogeneous behavior among different projectors or games.