### PR TITLE
fix(enlight): correct invGammaDenom — denominator is M²·T not M·T

### DIFF
--- a/src/enlight/Enlight.cpp
+++ b/src/enlight/Enlight.cpp
@@ -489,7 +489,7 @@ EnlightResult Enlight::classify() {
         const float k_R = _satKValidCount[0] ? _satKSum[0] / (float)_satKValidCount[0] : 0.0f;
         const float k_G = _satKValidCount[1] ? _satKSum[1] / (float)_satKValidCount[1] : 0.0f;
         const float k_B = _satKValidCount[2] ? _satKSum[2] / (float)_satKValidCount[2] : 0.0f;
-        const float invGammaDenom = 2.0f / ((float)SIN_MAG * (float)_goertzPeriod);
+        const float invGammaDenom = 2.0f / ((float)SIN_MAG * (float)SIN_MAG * (float)_goertzPeriod);
         // STEP1: k correction — always apply when saturation exists.
         // Restores the missing DC contribution from saturated samples.
         _rout  = (long long)((float)_rout  + k_R * (float)cSatCorr_far);


### PR DESCRIPTION
The formula has 2/(T·M²) but the code had 2/(T·M), missing one factor of M = SIN_MAG = 2048.  This made gammaF 2048× too extreme: a single saturated sample at the worst phase gave gammaF ≈ −40 instead of the correct 0.98. The |gammaF|>0.05 guard then applied STEP2 with a massively negative factor, sign-flipping all correlator outputs and producing the observed negative R/G/B.

https://claude.ai/code/session_01C46tVCShwEgX6x3q4gkihS