### PR TITLE
Fix missing EnlightCalib struct members and NVS keys for per-channel …

### DIFF
--- a/src/nvs_config.cpp
+++ b/src/nvs_config.cpp
@@ -81,16 +81,20 @@ bool enlight_calib_load(EnlightCalib& cal) {
         NVS_GET_FLOAT(h, CAL_KEY_RFACT,          cal.rfact,       1.0f);
         NVS_GET_FLOAT(h, CAL_KEY_BFACT,          cal.bfact,       1.0f);
         NVS_GET_FLOAT(h, CAL_KEY_NEAR_RATIO_MAX, cal.nearRatioMax, 1e9f);
-        NVS_GET_U32  (h, CAL_KEY_MAX_NEAR_WHITE, cal.maxNearWhite, 0);
-        NVS_GET_U32  (h, CAL_KEY_MAX_FAR_WHITE,  cal.maxFarWhite,  0);
+        NVS_GET_U32  (h, CAL_KEY_THRESH_NEAR_R,  cal.thresh_near_r, 0);
+        NVS_GET_U32  (h, CAL_KEY_THRESH_NEAR_G,  cal.thresh_near_g, 0);
+        NVS_GET_U32  (h, CAL_KEY_THRESH_NEAR_B,  cal.thresh_near_b, 0);
+        NVS_GET_U32  (h, CAL_KEY_THRESH_FAR_R,   cal.thresh_far_r,  0);
+        NVS_GET_U32  (h, CAL_KEY_THRESH_FAR_G,   cal.thresh_far_g,  0);
+        NVS_GET_U32  (h, CAL_KEY_THRESH_FAR_B,   cal.thresh_far_b,  0);
         nvs_close(h);
     } else {
         cal = {};
         cal.limpow = 0;
         cal.rfact = cal.bfact = 1.0f;
         cal.nearRatioMax = 1e9f;
-        cal.maxNearWhite = 0;
-        cal.maxFarWhite  = 0;
+        cal.thresh_near_r = cal.thresh_near_g = cal.thresh_near_b = 0;
+        cal.thresh_far_r  = cal.thresh_far_g  = cal.thresh_far_b  = 0;
         ESP_LOGW(TAG, "Calibration namespace missing -- using sentinels");
     }
     return true;
@@ -111,8 +115,12 @@ bool enlight_calib_save(const EnlightCalib& cal) {
     nvs_set_blob(h, CAL_KEY_RFACT,          &cal.rfact,        sizeof(float));
     nvs_set_blob(h, CAL_KEY_BFACT,          &cal.bfact,        sizeof(float));
     nvs_set_blob(h, CAL_KEY_NEAR_RATIO_MAX, &cal.nearRatioMax, sizeof(float));
-    nvs_set_u32 (h, CAL_KEY_MAX_NEAR_WHITE, cal.maxNearWhite);
-    nvs_set_u32 (h, CAL_KEY_MAX_FAR_WHITE,  cal.maxFarWhite);
+    nvs_set_u32 (h, CAL_KEY_THRESH_NEAR_R,  cal.thresh_near_r);
+    nvs_set_u32 (h, CAL_KEY_THRESH_NEAR_G,  cal.thresh_near_g);
+    nvs_set_u32 (h, CAL_KEY_THRESH_NEAR_B,  cal.thresh_near_b);
+    nvs_set_u32 (h, CAL_KEY_THRESH_FAR_R,   cal.thresh_far_r);
+    nvs_set_u32 (h, CAL_KEY_THRESH_FAR_G,   cal.thresh_far_g);
+    nvs_set_u32 (h, CAL_KEY_THRESH_FAR_B,   cal.thresh_far_b);
     esp_err_t e = nvs_commit(h); nvs_close(h);
     return e == ESP_OK;
 }

--- a/src/nvs_config.h
+++ b/src/nvs_config.h
@@ -65,9 +65,9 @@ struct EnlightCalib {
     uint32_t    phaseOff;                     // goertzTab phase offset (LED excitation delay, in samples)
     float       rfact, bfact;
     float       nearRatioMax;
-    // Step 3 — white diffusing surface calibration
-    uint32_t    maxNearWhite; // Max Near White: peak near-channel power over white-wall sweep
-    uint32_t    maxFarWhite;  // Max Far White:  peak far-channel  power over white-wall sweep
+    // Step 3 — per-channel low-power thresholds (white-wall sweep)
+    uint32_t    thresh_near_r, thresh_near_g, thresh_near_b;
+    uint32_t    thresh_far_r,  thresh_far_g,  thresh_far_b;
 };
 
 bool enlight_calib_load(EnlightCalib& cal);

--- a/src/tools/EnlightCalibRoutine.cpp
+++ b/src/tools/EnlightCalibRoutine.cpp
@@ -288,8 +288,8 @@ void EnlightCalibRoutine::step3() {
 
     // Show results.
     char l0[24], l1[24];
-    snprintf(l0, sizeof(l0), "NearMax: %lu", (unsigned long)maxNear);
-    snprintf(l1, sizeof(l1), "FarMax:  %lu", (unsigned long)maxFar);
+    snprintf(l0, sizeof(l0), "NrMax R:%lu G:%lu", (unsigned long)maxNear_r, (unsigned long)maxNear_g);
+    snprintf(l1, sizeof(l1), "FrMax R:%lu G:%lu", (unsigned long)maxFar_r,  (unsigned long)maxFar_g);
     showLines(l0, l1, nullptr, nullptr, nullptr, "TRIG2: done");
     waitTrig(TRIG_2_ID);
 }
@@ -305,7 +305,7 @@ void EnlightCalibRoutine::step4() {
 
     // Build one formatted line per calibration value.
     struct CalEntry { char line[22]; };
-    const uint8_t N_ENTRIES    = 13;
+    const uint8_t N_ENTRIES    = 17;
     const uint8_t ROWS_PER_PAGE = 5;
     const uint8_t N_PAGES      = (N_ENTRIES + ROWS_PER_PAGE - 1) / ROWS_PER_PAGE;
 
@@ -321,8 +321,12 @@ void EnlightCalibRoutine::step4() {
     snprintf(entries[8].line,  sizeof(entries[8].line),  "rfact:  %.4g", (double)cal.rfact);
     snprintf(entries[9].line,  sizeof(entries[9].line),  "bfact:  %.4g", (double)cal.bfact);
     snprintf(entries[10].line, sizeof(entries[10].line), "nRatMx: %.4g", (double)cal.nearRatioMax);
-    snprintf(entries[11].line, sizeof(entries[11].line), "mxNrW:  %lu",  (unsigned long)cal.maxNearWhite);
-    snprintf(entries[12].line, sizeof(entries[12].line), "mxFrW:  %lu",  (unsigned long)cal.maxFarWhite);
+    snprintf(entries[11].line, sizeof(entries[11].line), "thNrR:  %lu",  (unsigned long)cal.thresh_near_r);
+    snprintf(entries[12].line, sizeof(entries[12].line), "thNrG:  %lu",  (unsigned long)cal.thresh_near_g);
+    snprintf(entries[13].line, sizeof(entries[13].line), "thNrB:  %lu",  (unsigned long)cal.thresh_near_b);
+    snprintf(entries[14].line, sizeof(entries[14].line), "thFrR:  %lu",  (unsigned long)cal.thresh_far_r);
+    snprintf(entries[15].line, sizeof(entries[15].line), "thFrG:  %lu",  (unsigned long)cal.thresh_far_g);
+    snprintf(entries[16].line, sizeof(entries[16].line), "thFrB:  %lu",  (unsigned long)cal.thresh_far_b);
 
     uint8_t page = 0;
     for (;;) {


### PR DESCRIPTION
…thresholds

The previous commit split low-power thresholds into per-channel (r/g/b) values in Enlight.cpp and EnlightCalibRoutine.cpp, but forgot to update the EnlightCalib struct and nvs_config.cpp to match. Replace maxNearWhite/maxFarWhite with thresh_near_r/g/b and thresh_far_r/g/b throughout, and expand step4 display from 13 to 17 entries to show all six threshold channels.

https://claude.ai/code/session_0187TacU9nG7Wh53MjwAp3g6