### PR TITLE
Replace NEAR_PHASE_GATE with rho/phase gates; add noise/rho/coord-error dagnostics

### DIFF
--- a/sketches/LightAir_EnlightTest/LightAir_EnlightTest.ino
+++ b/sketches/LightAir_EnlightTest/LightAir_EnlightTest.ino
@@ -366,15 +366,23 @@ static void takeMeasurement() {
     } else {
         EnlightRawMeasure  raw   = enlight->rawMeasure();
         EnlightColorCoords color = enlight->colorCoords();
+        EnlightNoiseVar    nv    = enlight->noiseVariance();
+        EnlightRhoVec      rho   = enlight->rhoVec();
+        EnlightCoordErr    ce    = enlight->coordErrors();
 
         snprintf(line, sizeof(line),
-            "ELAB,%lu,%s,%u,%lld,%lld,%lld,%lld,%lld,%lld,%.6f,%.6f,%lu\n",
+            "ELAB,%lu,%s,%u,%lld,%lld,%lld,%lld,%lld,%lld,%.6f,%.6f,%lu"
+            ",%u,%.4f,%.4f,%.4f,%.2f,%.2f,%.2f,%.6f,%.6f\n",
             (unsigned long)ts,
             statusStr(res.status), res.id,
             raw.rout,  raw.gout,  raw.bout,
             raw.rnear, raw.gnear, raw.bnear,
             color.outr, color.outang,
-            (unsigned long)raw.satCount);
+            (unsigned long)raw.satCount,
+            (unsigned)ENLIGHT_REPS,
+            nv.r, nv.g, nv.b,
+            rho.r, rho.g, rho.b,
+            ce.outr, ce.outang);
         tcpClient.print(line);
     }
 
@@ -399,6 +407,7 @@ void setup() {
     // Enlight init
     enlight_calib_load(enlightCalib);
     enlight = new Enlight(enlightCalib);
+    enlight->setRepetitions(ENLIGHT_REPS);
     if (!enlight->begin()) {
         dispBegin();
         dispRow(0, "Enlight init");
@@ -458,7 +467,8 @@ void loop() {
                     "rout(far-R),gout(far-G),bout(far-B),"
                     "rnear(near-R),gnear(near-G),bnear(near-B),"
                     "outr(norm),outang,"
-                    "satCount\n");
+                    "satCount,"
+                    "reps,noiseVar_r,noiseVar_g,noiseVar_b,rho_r,rho_g,rho_b,err_outr,err_outang\n");
             }
         } else {
             if (millis() - lastDispMs > 500) {

--- a/src/config.h
+++ b/src/config.h
@@ -169,8 +169,9 @@ namespace EnlightDefaults {
     constexpr float    SAT_DITCH_FRAC  = 0.95f; // ditch period if any channel has >95% saturated samples
     constexpr float    SAT_SWITCH_FRAC = 0.02f; // switch to low-power PDM if >2% of a cycle's active samples saturated
     constexpr float    LOW_POWER_FACTOR = 0.1f; // amplitude scale for the dim PDM buffer
-    constexpr float    NEAR_PHASE_DEG    = 70.0f;   // φ > this → NEAR diffuser (degrees)
-    constexpr float    NEAR_PHASE_GATE_Z = 3.00f;   // phase-gate z-score threshold
+    constexpr float RHO_MIN_THRESHOLD = 350.0f;  // best-channel rho must exceed this → else NO_HIT
+    constexpr float FAR_HIT_PHASE_DEG = 10.0f;   // |φ| must be below this → else NEAR (degrees)
+    constexpr float COORD_ERR_K       = 2.576f;  // z-score for 99 % CI in coord error propagation
 }
 
 // ---------------------------------------------------------------

--- a/src/enlight/Enlight.cpp
+++ b/src/enlight/Enlight.cpp
@@ -251,6 +251,10 @@ bool Enlight::run() {
         _iqMeanI[ch] = _iqMeanQ[ch] = _iqM2I[ch] = _iqM2Q[ch] = 0.f;
     _iqCount   = 0;
     _phaseGate = {};
+    for (int ch = 0; ch < (int)ADC_CHANNELS; ch++)
+        _noiseVar[ch] = _rhoArr[ch] = 0.f;
+    _coordErr[0] = _coordErr[1] = -1.f;
+    _diagValid = false;
     _active=true;
     _firstCycle=true;
     gpio_set_level((gpio_num_t)EnlightDefaults::AFE_ON,1);
@@ -544,32 +548,34 @@ EnlightResult Enlight::classify() {
              _rawsum, rout, gout, bout, _rnear, _gnear, _bnear,
              (unsigned long)_satCount);
 
-    // Per-channel I/Q phase gate — uses Welford per-period variance for scale-invariant SNR.
-    // Gate passes (OR logic) if any channel's SNR ≥ NEAR_PHASE_GATE_Z.
-    // The best-SNR channel's phase determines FAR vs NEAR classification.
     {
-        const float phi_thresh_rad = EnlightDefaults::NEAR_PHASE_DEG * ((float)M_PI / 180.f);
-        const float sqrtN          = sqrtf((float)_iqCount);
-        float best_snr = 0.f, best_phi = 0.f;
-        bool  gate_ok  = false;
-        for (int ch = 0; ch < (int)ADC_CHANNELS; ch++) {
-            if (_iqCount < 2) continue;
-            const float sigma_p = sqrtf(0.5f * (_iqM2I[ch] + _iqM2Q[ch]) / (float)(_iqCount - 1));
-            if (sigma_p <= 0.f) continue;
-            const float R_mean = sqrtf(_iqMeanI[ch]*_iqMeanI[ch] + _iqMeanQ[ch]*_iqMeanQ[ch]);
-            const float phi_ch = atan2f(_iqMeanQ[ch], _iqMeanI[ch]);
-            const float snr    = fabsf(phi_ch - phi_thresh_rad) * R_mean * sqrtN / sigma_p;
-            if (snr >= EnlightDefaults::NEAR_PHASE_GATE_Z) gate_ok = true;
-            if (snr > best_snr) { best_snr = snr; best_phi = phi_ch; }
+        float best_rho = 0.f, best_phi = 0.f;
+        int   best_ch  = 0;
+        if (_iqCount >= 2) {
+            for (int ch = 0; ch < (int)ADC_CHANNELS; ch++) {
+                const float sigma_eta2 = (_iqM2I[ch] + _iqM2Q[ch]) / (2.f * (_iqCount - 1));
+                _noiseVar[ch]          = sigma_eta2;
+                const float M_hat2     = _iqMeanI[ch]*_iqMeanI[ch] + _iqMeanQ[ch]*_iqMeanQ[ch];
+                const float rho        = (sigma_eta2 > 0.f)
+                                         ? 2.f * (float)_iqCount * M_hat2 / sigma_eta2 : 0.f;
+                _rhoArr[ch]            = rho;
+                const float phi_ch     = atan2f(_iqMeanQ[ch], _iqMeanI[ch]);
+                if (rho > best_rho) { best_rho = rho; best_phi = phi_ch; best_ch = ch; }
+            }
         }
         _phaseGate.phiDeg   = best_phi * (180.f / (float)M_PI);
-        _phaseGate.snrPhase = best_snr;
-        ESP_LOGD(TAG, "phi=%.1f snr_phase=%.2f gate=%d",
-                 (double)_phaseGate.phiDeg, (double)_phaseGate.snrPhase, (int)gate_ok);
+        _phaseGate.snrPhase = best_rho;
+        _coordErr[0] = _coordErr[1] = -1.f;
+        _diagValid = true;
+        ESP_LOGD(TAG, "phi=%.1f best_rho=%.1f ch=%d",
+                 (double)_phaseGate.phiDeg, (double)best_rho, best_ch);
 
-        if (!gate_ok)                          return {EnlightStatus::NO_HIT, 0};
-        if (best_phi > phi_thresh_rad)         return classifyNear();
-        // best_phi ≤ threshold → FAR retroreflector: fall through to colour-box matching.
+        if (best_rho < EnlightDefaults::RHO_MIN_THRESHOLD)
+            return {EnlightStatus::NO_HIT, 0};
+        const float far_hit_rad = EnlightDefaults::FAR_HIT_PHASE_DEG * ((float)M_PI / 180.f);
+        if (fabsf(best_phi) >= far_hit_rad)
+            return classifyNear();
+        // rho OK and |φ| < FAR_HIT_PHASE_DEG → fall through to colour-box matching.
     }
 
     float outr = rout * _cal.rfact, outb = bout * _cal.bfact, outg = (float)gout;
@@ -578,6 +584,27 @@ EnlightResult Enlight::classify() {
     outr /= s; outg /= s;
     const float outang = (outr < 1.0f) ? (outg / (1.0f - outr)) : 1.0f;
     _colorCoords = {outr, outang};
+    if (_iqCount >= 2) {
+        const float vR = (float)_iqCount * _iqM2I[0] / (float)(_iqCount - 1);
+        const float vG = (float)_iqCount * _iqM2I[1] / (float)(_iqCount - 1);
+        const float vB = (float)_iqCount * _iqM2I[2] / (float)(_iqCount - 1);
+        const float R  = (float)rout * _cal.rfact;
+        const float G  = (float)gout;
+        const float B  = (float)bout * _cal.bfact;
+        const float S  = R + G + B;
+        if (S > 0.f) {
+            const float GB = G + B;
+            const float s2 = S * S;
+            const float var_outr = (GB*GB * _cal.rfact*_cal.rfact * vR
+                                  + R*R * vG
+                                  + R*R * _cal.bfact*_cal.bfact * vB) / (s2 * s2);
+            const float T  = G + B;
+            const float t2 = T * T;
+            const float var_outang = (B*B * vG + G*G * _cal.bfact*_cal.bfact * vB) / (t2 * t2);
+            _coordErr[0] = EnlightDefaults::COORD_ERR_K * sqrtf(fmaxf(0.f, var_outr));
+            _coordErr[1] = EnlightDefaults::COORD_ERR_K * sqrtf(fmaxf(0.f, var_outang));
+        }
+    }
     int hit = -1;
     for (int p = 1; p < CALIB_MAX_PLAYERS; p++) {
         const float* b = colorBox::colorBox[p];
@@ -600,6 +627,19 @@ EnlightResult Enlight::classify() {
  * ============================================================ */
 EnlightResult Enlight::classifyNear() {
     return {EnlightStatus::NEAR,0};
+}
+
+EnlightNoiseVar Enlight::noiseVariance() const {
+    if (!_diagValid) return {-1.f, -1.f, -1.f};
+    return {_noiseVar[0], _noiseVar[1], _noiseVar[2]};
+}
+EnlightRhoVec Enlight::rhoVec() const {
+    if (!_diagValid) return {-1.f, -1.f, -1.f};
+    return {_rhoArr[0], _rhoArr[1], _rhoArr[2]};
+}
+EnlightCoordErr Enlight::coordErrors() const {
+    if (!_diagValid || _coordErr[0] < 0.f) return {-1.f, -1.f};
+    return {_coordErr[0], _coordErr[1]};
 }
 
 /* ============================================================

--- a/src/enlight/Enlight.h
+++ b/src/enlight/Enlight.h
@@ -68,11 +68,15 @@ struct EnlightColorCoords {
 
 // I/Q phase-gate diagnostics from the last classify() call.
 // phiDeg: best-channel I/Q phase in degrees (atan2(NEAR,FAR)).
-// snrPhase: gate SNR = |φ − φ_thresh| × R_mean × √N / σ_period of the best channel.
+// snrPhase: best-channel rho (= 2N|M̂|²/σ²_η) — signal-to-noise non-centrality parameter.
 struct EnlightPhaseGate {
     float phiDeg   = 0.f;
     float snrPhase = 0.f;
 };
+
+struct EnlightNoiseVar  { float r, g, b; };          // σ²_η per channel; -1 if stale
+struct EnlightRhoVec    { float r, g, b; };          // rho per channel;  -1 if stale
+struct EnlightCoordErr  { float outr, outang; };     // 99%-CI half-widths; -1 if no FAR hit
 
 class Enlight
 {
@@ -127,6 +131,9 @@ public:
     EnlightRawMeasure   rawMeasure()   const;
     EnlightColorCoords  colorCoords()  const { return _colorCoords; }
     EnlightPhaseGate    phaseGate()    const { return _phaseGate;   }
+    EnlightNoiseVar     noiseVariance() const;
+    EnlightRhoVec       rhoVec()        const;
+    EnlightCoordErr     coordErrors()   const;
     const EnlightCalib& calib()        const { return _cal; }
 
     // Access to the raw ADC DMA buffer from the last completed DMA cycle.
@@ -220,13 +227,17 @@ private:
     uint32_t    _arrayiter = 0;
     uint32_t    _satCount  = 0;
 
-    // Per-channel per-period I/Q Welford estimator for the phase-confidence gate.
+    // Per-channel per-period I/Q Welford estimator.
     float    _iqMeanI[ADC_CHANNELS] = {};  // running per-period FAR mean, per channel
     float    _iqMeanQ[ADC_CHANNELS] = {};  // running per-period NEAR mean, per channel
     float    _iqM2I  [ADC_CHANNELS] = {};  // Welford M2 for FAR, per channel
     float    _iqM2Q  [ADC_CHANNELS] = {};  // Welford M2 for NEAR, per channel
     uint32_t _iqCount = 0;                  // active periods counted (shared across channels)
     EnlightPhaseGate _phaseGate     = {};   // last classify() result, for diagnostics
+    float         _noiseVar[ADC_CHANNELS] = {};  // σ²_η per channel
+    float         _rhoArr  [ADC_CHANNELS] = {};  // rho per channel
+    float         _coordErr[2]            = {};  // 99%-CI for outr, outang
+    volatile bool _diagValid              = false;
 
     // Result -- written by dmaTask (core 0), read-cleared by poll() (any core).
     portMUX_TYPE    _mux                = portMUX_INITIALIZER_UNLOCKED;


### PR DESCRIPTION

- Remove NEAR_PHASE_DEG and NEAR_PHASE_GATE_Z; add RHO_MIN_THRESHOLD (350), FAR_HIT_PHASE_DEG (10°), and COORD_ERR_K (2.576) to EnlightDefaults
- classify(): single-pass loop computes σ²_η and rho per channel, selects best_ch by rho; rho < threshold → NO_HIT, |φ| ≥ FAR_HIT_PHASE_DEG → NEAR
- phaseGate().snrPhase repurposed to carry best-channel rho
- New structs EnlightNoiseVar/EnlightRhoVec/EnlightCoordErr with getters noiseVariance(), rhoVec(), coordErrors(); _diagValid guards sentinel return
- Color-coordinate 99%-CI error propagation via delta method after FAR hit
- EnlightTest: wire ENLIGHT_REPS via setRepetitions(); ELAB CSV extended with reps, noiseVar_r/g/b, rho_r/g/b, err_outr, err_outang