### PR TITLE
Fix totem activation: session-token handoff, unified payload, self-revert watchdog

### DIFF
--- a/src/game/LightAir_Game.h
+++ b/src/game/LightAir_Game.h
@@ -230,6 +230,11 @@ struct LightAir_Game {
     uint8_t                          teamCount;   // 0 = teamless; 2–8 = number of teams
     uint8_t*                         teamMap;     // size MAX_PLAYER_ID; nullptr if teamCount==0
 
+    // Optional pointer to the ruleset's live in-game countdown (seconds remaining),
+    // e.g. &gameTimeLeft.  Sent to totems in the 0xF1 activation reply so they can
+    // arm a self-revert watchdog.  nullptr = ruleset has no such counter.
+    const int* gameTimeLeft;
+
     // Called by GameRunner immediately before esp_restart() after the player
     // presses A+B on the end-game screen.  Use for last-moment display updates
     // or NVS writes.  nullptr = skip.

--- a/src/game/LightAir_GameRunner.cpp
+++ b/src/game/LightAir_GameRunner.cpp
@@ -170,37 +170,15 @@ void LightAir_GameRunner::update() {
         }
     }
 
-    // MSG_TOTEM_BEACON: reply with the totem's assigned roleId in payload[0].
-    // payload[1] = *configSecs for this role if a requirement has one set.
+    // MSG_TOTEM_BEACON: reply with the totem's assigned role, the current session
+    // token, and the game's remaining time (see replyToTotemBeacon()).
     // No reply is sent to non-totem senders or unconfigured totems.
     for (uint8_t e = 0; e < radio.count; e++) {
         const RadioEvent& ev = radio.events[e];
         if (ev.type           != RadioEventType::MessageReceived) continue;
         if (ev.packet.msgType != RadioMsg::MSG_TOTEM_BEACON)      continue;
         infraHandled[e] = true;
-
-        uint8_t id = ev.packet.senderId;
-        if (!TotemDefs::isTotemId(id)) continue;
-
-        for (uint8_t t = 0; t < _totemCount; t++) {
-            if (_totems[t].id != id) continue;
-            uint8_t roleId = _totems[t].roleId;
-            uint8_t buf[2] = { roleId, 0 };
-            uint8_t bufLen = 1;
-            // Include configSecs if any requirement for this role has one.
-            if (_game->totemRequirements) {
-                for (uint8_t r = 0; r < _game->totemRequirementCount; r++) {
-                    const LightAir_TotemRequirement& req = _game->totemRequirements[r];
-                    if (req.roleId == roleId && req.configSecs != nullptr) {
-                        buf[1] = (uint8_t)*req.configSecs;
-                        bufLen = 2;
-                        break;
-                    }
-                }
-            }
-            output.radio.replyWithPayload(ev.packet, buf, bufLen);
-            break;
-        }
+        replyToTotemBeacon(ev, output);
     }
 
     // Step 2b: DirectRadioRules — handle all incoming MessageReceived events.
@@ -277,6 +255,8 @@ void LightAir_GameRunner::update() {
 
         // Flood MSG_END_GAME so devices still in a non-scoring state transition.
         output.radio.broadcast(GameDefaults::MSG_END_GAME, nullptr, 0, 2);
+        // Flood MSG_TOTEM_ROSTER so any activated totem reverts to stateless.
+        output.radio.broadcast(RadioMsg::MSG_TOTEM_ROSTER, nullptr, 0, 2);
         scoreBroadcastFused(output);
         _scoreSentAt = millis();
 
@@ -301,6 +281,50 @@ void LightAir_GameRunner::update() {
 
     // Enforce fixed loop duration.
     while ((millis() - loopStart) < GameDefaults::LOOP_MS) {}
+}
+
+/* =========================================================
+ *   TOTEM BEACON REPLY (0xF1) — shared by update() and scoreUpdate()
+ * ========================================================= */
+
+// Builds the activation reply for one MSG_TOTEM_BEACON event:
+//   payload[0]   = the totem's assigned roleId
+//   payload[1]   = the current session token (so the totem learns it for the
+//                  duration of the game)
+//   payload[2:3] = gameTimeLeft as uint16_t, big-endian, exact seconds;
+//                  0xFFFF if the ruleset has no live countdown to report
+//   payload[4]   = *configSecs for this role, only if a requirement has one set
+// No reply is sent to non-totem senders or totems with no assigned role.
+void LightAir_GameRunner::replyToTotemBeacon(const RadioEvent& ev, GameOutput& output) {
+    uint8_t id = ev.packet.senderId;
+    if (!TotemDefs::isTotemId(id)) return;
+
+    for (uint8_t t = 0; t < _totemCount; t++) {
+        if (_totems[t].id != id) continue;
+        uint8_t roleId = _totems[t].roleId;
+        uint8_t buf[5] = { roleId, _radio->sessionToken(), 0xFF, 0xFF, 0 };
+        uint8_t bufLen = 4;
+
+        if (_game->gameTimeLeft) {
+            uint16_t secs = (uint16_t)*_game->gameTimeLeft;   // exact, no rounding
+            buf[2] = (uint8_t)(secs >> 8);
+            buf[3] = (uint8_t)(secs & 0xFF);
+        }
+
+        // Include configSecs if any requirement for this role has one.
+        if (_game->totemRequirements) {
+            for (uint8_t r = 0; r < _game->totemRequirementCount; r++) {
+                const LightAir_TotemRequirement& req = _game->totemRequirements[r];
+                if (req.roleId == roleId && req.configSecs != nullptr) {
+                    buf[4] = (uint8_t)*req.configSecs;
+                    bufLen = 5;
+                    break;
+                }
+            }
+        }
+        output.radio.replyWithPayload(ev.packet, buf, bufLen);
+        break;
+    }
 }
 
 /* =========================================================
@@ -347,28 +371,7 @@ void LightAir_GameRunner::scoreUpdate(const InputReport& inputs,
         const RadioEvent& ev = radio.events[e];
         if (ev.type           != RadioEventType::MessageReceived) continue;
         if (ev.packet.msgType != RadioMsg::MSG_TOTEM_BEACON)      continue;
-
-        uint8_t id = ev.packet.senderId;
-        if (!TotemDefs::isTotemId(id)) continue;
-
-        for (uint8_t t = 0; t < _totemCount; t++) {
-            if (_totems[t].id != id) continue;
-            uint8_t roleId = _totems[t].roleId;
-            uint8_t buf[2] = { roleId, 0 };
-            uint8_t bufLen = 1;
-            if (_game->totemRequirements) {
-                for (uint8_t r = 0; r < _game->totemRequirementCount; r++) {
-                    const LightAir_TotemRequirement& req = _game->totemRequirements[r];
-                    if (req.roleId == roleId && req.configSecs != nullptr) {
-                        buf[1] = (uint8_t)*req.configSecs;
-                        bufLen = 2;
-                        break;
-                    }
-                }
-            }
-            output.radio.replyWithPayload(ev.packet, buf, bufLen);
-            break;
-        }
+        replyToTotemBeacon(ev, output);
     }
 
     // Timed retry — re-broadcast fused scores while waiting for all devices.

--- a/src/game/LightAir_GameRunner.h
+++ b/src/game/LightAir_GameRunner.h
@@ -131,6 +131,7 @@ private:
     void activateStateDisplay(uint8_t state);
     void flushOutput(const GameOutput& out);
     void scoreUpdate(const InputReport&, const RadioReport&, GameOutput&);
+    void replyToTotemBeacon(const RadioEvent& ev, GameOutput& output);
 
     // Score collection helpers (all defined in .cpp)
     void postScoreAnnounce();

--- a/src/game/LightAir_RadioOutput.h
+++ b/src/game/LightAir_RadioOutput.h
@@ -34,7 +34,7 @@ struct RadioReplyMsg {
     uint8_t  senderId;
     uint8_t  origMsgType;
     uint32_t origTimestamp;
-    uint8_t  payload[4];    // reply payload bytes
+    uint8_t  payload[5];    // reply payload bytes
     uint8_t  payloadLen;    // 0 = no payload
 };
 
@@ -92,11 +92,11 @@ struct RadioOutput {
         }
     }
 
-    // Queue a reply with an explicit multi-byte payload (up to 4 bytes).
+    // Queue a reply with an explicit multi-byte payload (up to 5 bytes).
     void replyWithPayload(const RadioPacket& original,
                           const uint8_t* pl, uint8_t len) {
         if (replyCount >= GameDefaults::RADIO_REPLY_MAX) return;
-        if (len > 4) len = 4;
+        if (len > 5) len = 5;
         RadioReplyMsg& r   = replies[replyCount++];
         r.senderId         = original.senderId;
         r.origMsgType      = original.msgType;

--- a/src/radio/LightAir_Radio.cpp
+++ b/src/radio/LightAir_Radio.cpp
@@ -212,9 +212,12 @@ bool LightAir_Radio::broadcastUniversal(uint8_t msgType,
 // ----------------------------------------------------------------
 void LightAir_Radio::processPacket(const RadioPacket& pkt, int8_t rssi) {
     // 1. Session token gate
-    // If own token is UNSET, accept all (device not yet in session).
-    // Once a token is set, only matching-token packets pass.
-    if (_sessionToken != RadioToken::UNSET &&
+    // pkt.sessionToken == UNSET always passes (infrastructure / not-yet-activated
+    // senders, e.g. totems before a projector has assigned them a token).
+    // _sessionToken == UNSET (own) always passes (device not yet in session).
+    // Otherwise: drop only if both sides have a token and they mismatch.
+    if (pkt.sessionToken != RadioToken::UNSET &&
+        _sessionToken    != RadioToken::UNSET &&
         pkt.sessionToken != _sessionToken) return;
 
     // 2. Game typeId gate

--- a/src/radio/LightAir_Radio.h
+++ b/src/radio/LightAir_Radio.h
@@ -165,6 +165,9 @@ public:
     // Active game typeId (read-back, e.g. for the totem driver).
     uint16_t typeId() const { return _typeId; }
 
+    // Active session token (read-back, e.g. for GameRunner's totem activation reply).
+    uint8_t sessionToken() const { return _sessionToken; }
+
     // Poll — call once per loop iteration.
     // Drains all received packets and checks all pending timeouts in one call.
     // Returns a reference valid until the next call to poll().

--- a/src/rulesets/GameFlag.cpp
+++ b/src/rulesets/GameFlag.cpp
@@ -607,5 +607,6 @@ extern const LightAir_Game game_flag = {
     /* totemRequirements     */ Flag::totemRequirements,   /* totemRequirementCount  */ 7,
     /* teamCount             */ 2,
     /* teamMap               */ Flag::teamMap,
+    /* gameTimeLeft          */ &Flag::gameTimeLeft,
     /* onEnd                 */ nullptr,
 };

--- a/src/rulesets/GameFreeForAll.cpp
+++ b/src/rulesets/GameFreeForAll.cpp
@@ -320,5 +320,6 @@ extern const LightAir_Game game_ffa = {
     /* totemRequirements     */ FFA::totemRequirements,  /* totemRequirementCount  */ 2,
     /* teamCount             */ 0,
     /* teamMap               */ nullptr,
+    /* gameTimeLeft          */ &FFA::gameTimeLeft,
     /* onEnd                 */ nullptr,
 };

--- a/src/rulesets/GameKingOfHill.cpp
+++ b/src/rulesets/GameKingOfHill.cpp
@@ -443,5 +443,6 @@ extern const LightAir_Game game_koh = {
     /* totemRequirements     */ KoH::totemRequirements,  /* totemRequirementCount  */ 4,
     /* teamCount             */ 0,
     /* teamMap               */ nullptr,
+    /* gameTimeLeft          */ &KoH::gameTimeLeft,
     /* onEnd                 */ nullptr,
 };

--- a/src/rulesets/GameOutflow.cpp
+++ b/src/rulesets/GameOutflow.cpp
@@ -353,5 +353,6 @@ extern const LightAir_Game game_outflow = {
     /* totemRequirements     */ Outflow::totemRequirements,  /* totemRequirementCount  */ 2,
     /* teamCount             */ 0,
     /* teamMap               */ nullptr,
+    /* gameTimeLeft          */ &Outflow::gameTimeLeft,
     /* onEnd                 */ nullptr,
 };

--- a/src/rulesets/GameTeams.cpp
+++ b/src/rulesets/GameTeams.cpp
@@ -453,5 +453,6 @@ extern const LightAir_Game game_teams = {
     /* totemRequirements     */ Teams::totemRequirements,  /* totemRequirementCount  */ 5,
     /* teamCount             */ 2,
     /* teamMap               */ Teams::teamMap,
+    /* gameTimeLeft          */ &Teams::gameTimeLeft,
     /* onEnd                 */ nullptr,
 };

--- a/src/rulesets/GameUpkeep.cpp
+++ b/src/rulesets/GameUpkeep.cpp
@@ -559,5 +559,6 @@ extern const LightAir_Game game_upkeep = {
     /* totemRequirementCount */ 6,
     /* teamCount             */ 2,
     /* teamMap               */ Upkeep::teamMap,
+    /* gameTimeLeft          */ &Upkeep::gameTimeLeft,
     /* onEnd                 */ nullptr,
 };

--- a/src/totem-rulesets/BaseTotem.cpp
+++ b/src/totem-rulesets/BaseTotem.cpp
@@ -21,9 +21,9 @@
 //   that support teamless bases can accept it from any player.
 //   Respawn animation still shows the respawning player's team colour.
 //
-// Activation payload
-//   payload[0] = roleId (BASE_O, BASE_X, or BASE) — team already known
-//                from construction; payload is ignored beyond confirming roleId.
+// Activation
+//   info.roleId = BASE_O, BASE_X, or BASE — team already known from
+//                 construction; info is otherwise unused.
 // ================================================================
 
 using RadioMsg::MSG_BASE_BEACON;
@@ -46,7 +46,7 @@ public:
     explicit BaseTotem(uint8_t team)
         : _team(team), _lastBeacon(0) {}
 
-    void onActivate(const uint8_t* /*payload*/, uint8_t /*len*/,
+    void onActivate(const LightAir_TotemActivation& /*info*/,
                     LightAir_TotemOutput& out) override {
         _lastBeacon = 0;
         uint8_t r = 0, g = 0, b = 0;

--- a/src/totem-rulesets/BonusTotem.cpp
+++ b/src/totem-rulesets/BonusTotem.cpp
@@ -9,9 +9,10 @@
 //              On player reply (0x5F) → COOLDOWN; triggers Bonus anim.
 //   COOLDOWN : silent; waits _cooldownSecs seconds then → READY; triggers Idle.
 //
-// Activation payload
-//   payload[0] = roleId (BONUS)
-//   payload[1] = cooldown interval in seconds (optional; default 30).
+// Activation
+//   info.roleId       = BONUS
+//   info.configSecs   = cooldown interval in seconds, if info.hasConfigSecs;
+//                       otherwise DEFAULT_COOLDOWN_SECS.
 //
 // The effect of the bonus is entirely determined by the player side.
 // The totem only governs timing: when it is claimable and when it resets.
@@ -35,10 +36,10 @@ public:
         : _state(BONUS_READY), _cooldownSecs(DEFAULT_COOLDOWN_SECS),
           _cooldownEnd(0), _lastBeacon(0) {}
 
-    void onActivate(const uint8_t* payload, uint8_t len,
+    void onActivate(const LightAir_TotemActivation& info,
                     LightAir_TotemOutput& out) override {
         _state        = BONUS_READY;
-        _cooldownSecs = (len >= 2) ? payload[1] : DEFAULT_COOLDOWN_SECS;
+        _cooldownSecs = info.hasConfigSecs ? info.configSecs : DEFAULT_COOLDOWN_SECS;
         _cooldownEnd  = 0;
         _lastBeacon   = 0;
         out.ui.trigger(TotemUIEvent::Idle);

--- a/src/totem-rulesets/CPTotem.cpp
+++ b/src/totem-rulesets/CPTotem.cpp
@@ -30,8 +30,8 @@
 //   when their RSSI to this totem is above their own proximity threshold.
 //   subType 0 (auto empty-reply) is ignored.
 //
-// Activation payload
-//   payload[0] = roleId (CP).  No additional config bytes needed.
+// Activation
+//   info.roleId = CP.  No additional config needed.
 // ================================================================
 
 using RadioMsg::MSG_CP_BEACON;
@@ -65,7 +65,7 @@ public:
         : _cpTeam(CP_TEAM_NONE), _presenceMask(0),
           _windowStart(0), _attachStart(0) {}
 
-    void onActivate(const uint8_t* /*payload*/, uint8_t /*len*/,
+    void onActivate(const LightAir_TotemActivation& /*info*/,
                     LightAir_TotemOutput& out) override {
         _cpTeam       = CP_TEAM_NONE;
         _presenceMask = 0;

--- a/src/totem-rulesets/FlagTotem.cpp
+++ b/src/totem-rulesets/FlagTotem.cpp
@@ -62,7 +62,7 @@ public:
     explicit FlagTotem(uint8_t team)
         : _team(team), _state(FLAG_STATE_IN), _lastBeacon(0) {}
 
-    void onActivate(const uint8_t* /*payload*/, uint8_t /*len*/,
+    void onActivate(const LightAir_TotemActivation& /*info*/,
                     LightAir_TotemOutput& out) override {
         _state      = FLAG_STATE_IN;
         _lastBeacon = 0;

--- a/src/totem-rulesets/MalusTotem.cpp
+++ b/src/totem-rulesets/MalusTotem.cpp
@@ -12,9 +12,10 @@
 //              On player reply (0x61) → COOLDOWN; triggers Malus anim.
 //   COOLDOWN : silent; waits _cooldownSecs seconds then → READY; triggers Idle.
 //
-// Activation payload
-//   payload[0] = roleId (MALUS)
-//   payload[1] = cooldown interval in seconds (optional; default 30).
+// Activation
+//   info.roleId       = MALUS
+//   info.configSecs   = cooldown interval in seconds, if info.hasConfigSecs;
+//                       otherwise DEFAULT_COOLDOWN_SECS.
 //
 // The effect of the malus is entirely determined by the player side.
 // ================================================================
@@ -37,10 +38,10 @@ public:
         : _state(MALUS_READY), _cooldownSecs(DEFAULT_COOLDOWN_SECS),
           _cooldownEnd(0), _lastBeacon(0) {}
 
-    void onActivate(const uint8_t* payload, uint8_t len,
+    void onActivate(const LightAir_TotemActivation& info,
                     LightAir_TotemOutput& out) override {
         _state        = MALUS_READY;
-        _cooldownSecs = (len >= 2) ? payload[1] : DEFAULT_COOLDOWN_SECS;
+        _cooldownSecs = info.hasConfigSecs ? info.configSecs : DEFAULT_COOLDOWN_SECS;
         _cooldownEnd  = 0;
         _lastBeacon   = 0;
         out.ui.trigger(TotemUIEvent::Idle);

--- a/src/totem/LightAir_TotemDriver.cpp
+++ b/src/totem/LightAir_TotemDriver.cpp
@@ -8,7 +8,7 @@ LightAir_TotemDriver::LightAir_TotemDriver(LightAir_Radio&            radio,
                                             LightAir_TotemUICtrl&      ui,
                                             LightAir_TotemRoleManager& roleMgr)
     : _radio(radio), _ui(ui), _roleMgr(roleMgr),
-      _runner(nullptr), _lastBeacon(0)
+      _runner(nullptr), _lastBeacon(0), _revertDeadline(0)
 {}
 
 // ----------------------------------------------------------------
@@ -33,7 +33,12 @@ void LightAir_TotemDriver::loop() {
         _radio.broadcastUniversal(MSG_TOTEM_BEACON);
     }
 
-    // ---- 2. Process incoming events ----
+    // ---- 2. Self-revert watchdog: no MSG_TOTEM_ROSTER ever arrived ----
+    if (_runner && _revertDeadline && now >= _revertDeadline) {
+        revertToIdle(out);
+    }
+
+    // ---- 3. Process incoming events ----
     for (uint8_t i = 0; i < report.count; i++) {
         const RadioEvent& ev = report.events[i];
 
@@ -49,28 +54,33 @@ void LightAir_TotemDriver::loop() {
         if (isRoster) {
             if (_runner) {
                 _runner->onRoster(ev.packet, out);
-                flushOutput(out);
-                out = LightAir_TotemOutput{};  // reset for next cycle
-                _runner->reset();
-                _runner = nullptr;
-                _radio.setTypeId(RadioTypeId::UNIVERSAL);
-                // Return to idle animation.
-                out.ui.trigger(TotemUIEvent::Idle);
+                revertToIdle(out);
             }
             continue;
         }
 
         // Activate runner on first 0xF1 activation reply.
-        // payload[0] holds the roleId.
         if (!_runner && incomingTypeId != RadioTypeId::UNIVERSAL) {
             if (ev.packet.msgType == (RadioMsg::MSG_TOTEM_BEACON + 1) &&
-                ev.packet.payloadLen >= 1) {
+                ev.packet.payloadLen >= 4) {
                 uint8_t roleId = ev.packet.payload[0];
                 const TotemRole* role = _roleMgr.findById(roleId);
                 if (role && role->runner) {
+                    LightAir_TotemActivation info;
+                    info.roleId           = roleId;
+                    info.sessionToken     = ev.packet.payload[1];
+                    info.gameTimeLeftSecs = ((uint16_t)ev.packet.payload[2] << 8) |
+                                             ev.packet.payload[3];
+                    info.hasConfigSecs    = ev.packet.payloadLen >= 5;
+                    info.configSecs       = info.hasConfigSecs ? ev.packet.payload[4] : 0;
+
                     _runner = role->runner;
                     _radio.setTypeId(incomingTypeId);
-                    _runner->onActivate(ev.packet.payload, ev.packet.payloadLen, out);
+                    _radio.setSessionToken(info.sessionToken);
+                    _revertDeadline = (info.gameTimeLeftSecs == 0xFFFF)
+                        ? 0
+                        : now + (uint32_t)(info.gameTimeLeftSecs + 10) * 1000;
+                    _runner->onActivate(info, out);
                 }
             }
             continue;
@@ -82,16 +92,26 @@ void LightAir_TotemDriver::loop() {
         }
     }
 
-    // ---- 3. Periodic runner update ----
+    // ---- 4. Periodic runner update ----
     if (_runner) {
         _runner->update(out);
     }
 
-    // ---- 4. Flush output ----
+    // ---- 5. Flush output ----
     flushOutput(out);
 
-    // ---- 5. Advance strip animation ----
+    // ---- 6. Advance strip animation ----
     _ui.update();
+}
+
+// ----------------------------------------------------------------
+void LightAir_TotemDriver::revertToIdle(LightAir_TotemOutput& out) {
+    _runner->reset();
+    _runner = nullptr;
+    _radio.setTypeId(RadioTypeId::UNIVERSAL);
+    _radio.setSessionToken(RadioToken::UNSET);
+    _revertDeadline = 0;
+    out.ui.trigger(TotemUIEvent::Idle);
 }
 
 // ----------------------------------------------------------------

--- a/src/totem/LightAir_TotemDriver.h
+++ b/src/totem/LightAir_TotemDriver.h
@@ -47,9 +47,15 @@ private:
     LightAir_TotemUICtrl&      _ui;
     LightAir_TotemRoleManager& _roleMgr;
 
-    LightAir_TotemRunner* _runner;      // nullptr = IDLE
-    uint32_t              _lastBeacon;  // millis() of last beacon broadcast
+    LightAir_TotemRunner* _runner;          // nullptr = IDLE
+    uint32_t              _lastBeacon;      // millis() of last beacon broadcast
+    uint32_t              _revertDeadline;  // millis() deadline for self-revert; 0 = no watchdog armed
 
     // Flush all queued radio and UI commands to the hardware.
     void flushOutput(LightAir_TotemOutput& out);
+
+    // Shared teardown: reset()s the runner, clears role/token/typeId, and
+    // returns to the Idle animation.  Used both when MSG_TOTEM_ROSTER arrives
+    // and when the self-revert watchdog elapses without one.
+    void revertToIdle(LightAir_TotemOutput& out);
 };

--- a/src/totem/LightAir_TotemRunner.h
+++ b/src/totem/LightAir_TotemRunner.h
@@ -10,26 +10,33 @@
 // Multiple instances of the same subclass may run on different
 // totem devices simultaneously.
 //
-// Lifecycle managed by LightAir_TotemDriver:
+// A totem is stateless (no role, no session token, no typeId) only
+// *between* games.  Lifecycle managed by LightAir_TotemDriver:
 //
-//   IDLE  → (first game-typeId packet received) → ACTIVE
-//            driver calls onMessage() with the activation packet,
-//            then update() every tick.
+//   IDLE  → (first 0xF1 activation reply received) → ACTIVE
+//            driver decodes the reply into a LightAir_TotemActivation,
+//            adopts its session token, and calls onActivate(info, out);
+//            then onMessage() for subsequent packets, update() every tick.
 //
-//   ACTIVE → (MSG_TOTEM_ROSTER received) → IDLE
-//            driver calls onRoster() (which queues the reply),
-//            then reset() to clear all state.
+//   ACTIVE → (MSG_TOTEM_ROSTER received, or the self-revert watchdog
+//             elapses without one arriving) → IDLE
+//            driver calls onRoster() (which queues the reply) when roster
+//            arrives, then reset() and clears role/token/typeId either way
+//            so the totem is fully stateless again for the next game.
 //
 // Activation protocol — MSG_TOTEM_BEACON reply (msgType 0xF1):
 //   The GameRunner infrastructure (on the host device only) replies to
-//   every MSG_TOTEM_BEACON from a configured totem with 0xF1:
+//   every MSG_TOTEM_BEACON from a configured totem with 0xF1, carrying:
+//     - the assigned roleId
+//     - the host's current session token (the totem adopts it for the game)
+//     - the game's live remaining-time counter, used to arm a self-revert
+//       watchdog (~10s margin) in case MSG_TOTEM_ROSTER is never received
+//     - optional per-role config (e.g. cooldown seconds for BONUS/MALUS)
 //
-//     payload[0] = roleId  (TotemRoleId::BASE_O … MALUS)
-//     payload[1] = optional per-role config (e.g. cooldown seconds)
-//
-//   TotemDriver looks up the runner via LightAir_TotemRoleManager and
-//   calls runner->onActivate(payload, len, out).  onMessage() is NOT
-//   called with the activation packet.
+//   TotemDriver looks up the runner via LightAir_TotemRoleManager, decodes
+//   the reply into a LightAir_TotemActivation, and calls
+//   runner->onActivate(info, out).  onMessage() is NOT called with the
+//   activation packet.
 //
 //   Unconfigured and non-totem senders receive no reply.
 //
@@ -46,19 +53,31 @@
 //       void reset() override { /* clear counters */ }
 //   };
 // ----------------------------------------------------------------
+
+// Decoded contents of one 0xF1 activation reply.  Built once by
+// LightAir_TotemDriver from the raw packet payload and passed to every
+// role's onActivate(), instead of each role re-deriving its own fields
+// from raw payload[] indices.
+struct LightAir_TotemActivation {
+    uint8_t  roleId;
+    uint8_t  sessionToken;
+    uint16_t gameTimeLeftSecs;   // 0xFFFF = unknown / no watchdog budget
+    bool     hasConfigSecs;
+    uint8_t  configSecs;        // valid only if hasConfigSecs
+};
+
 class LightAir_TotemRunner {
 public:
     virtual ~LightAir_TotemRunner() = default;
 
     // Called once when the activation reply (0xF1) is received with a
-    // known roleId.  payload[0] = roleId; payload[1..] = optional per-role
-    // config bytes (e.g. cooldown seconds for BONUS/MALUS).
-    // Use for identity animations and reading config from the payload.
+    // known roleId.  Use for identity animations and reading per-role
+    // config out of info.
     // Default: calls reset() — backward-compatible with legacy runners
     // that do not override this method.
-    virtual void onActivate(const uint8_t* payload, uint8_t len,
+    virtual void onActivate(const LightAir_TotemActivation& info,
                             LightAir_TotemOutput& out) {
-        (void)payload; (void)len; (void)out;
+        (void)info; (void)out;
         reset();
     }
 


### PR DESCRIPTION
Totems never picked up their assigned role in a real game because the projector's session-token gate dropped every pre-activation totem beacon (totems start tokenless and only learn a token once activated). Fix the gate to exempt tokenless senders symmetrically with tokenless receivers, have totems adopt the session token from their 0xF1 activation reply, and broadcast MSG_TOTEM_ROSTER at game end so totems actually revert to idle (previously dead code). Also unify per-role activation payload decoding into a single LightAir_TotemActivation struct built once by LightAir_TotemDriver, and arm a self-revert watchdog (gameTimeLeft + 10s margin) so a totem that loses radio contact before roster arrives still returns to a clean idle state.