### PR TITLE
RSSI gate established (with a trick), flag spam fixed, totem re-initialized at end-game

### DIFF
--- a/src/game/LightAir_GameRunner.cpp
+++ b/src/game/LightAir_GameRunner.cpp
@@ -256,7 +256,10 @@ void LightAir_GameRunner::update() {
         // Flood MSG_END_GAME so devices still in a non-scoring state transition.
         output.radio.broadcast(GameDefaults::MSG_END_GAME, nullptr, 0, 2);
         // Flood MSG_TOTEM_ROSTER so any activated totem reverts to stateless.
+        // A single broadcast can be lost, so scoreUpdate() keeps re-sending it
+        // for the duration of the end-game screen (see _rosterSentAt).
         output.radio.broadcast(RadioMsg::MSG_TOTEM_ROSTER, nullptr, 0, 2);
+        _rosterSentAt = millis();
         scoreBroadcastFused(output);
         _scoreSentAt = millis();
 
@@ -366,12 +369,14 @@ void LightAir_GameRunner::scoreUpdate(const InputReport& inputs,
         }
     }
 
-    // MSG_TOTEM_BEACON: no DirectRadioRules run in scoring phase; reply directly.
-    for (uint8_t e = 0; e < radio.count; e++) {
-        const RadioEvent& ev = radio.events[e];
-        if (ev.type           != RadioEventType::MessageReceived) continue;
-        if (ev.packet.msgType != RadioMsg::MSG_TOTEM_BEACON)      continue;
-        replyToTotemBeacon(ev, output);
+    // MSG_TOTEM_BEACON: the game is over, so do NOT answer beacons with a role
+    // activation here — doing so would immediately re-activate any totem that
+    // just reverted to its stateless state, bouncing it back into game mode.
+    // Instead we periodically re-broadcast MSG_TOTEM_ROSTER (below) to drive all
+    // totems back to stateless; reverted totems ignore repeats harmlessly.
+    if (millis() - _rosterSentAt >= GameDefaults::PRESTART_BROADCAST_MS) {
+        output.radio.broadcast(RadioMsg::MSG_TOTEM_ROSTER, nullptr, 0, 2);
+        _rosterSentAt = millis();
     }
 
     // Timed retry — re-broadcast fused scores while waiting for all devices.

--- a/src/game/LightAir_GameRunner.h
+++ b/src/game/LightAir_GameRunner.h
@@ -125,6 +125,7 @@ private:
     uint32_t _scorePresent     = 0;       // bit id set = _scoreSlots[id] is valid (player-ID-indexed)
     uint32_t _scoreSentAt      = 0;       // millis() of last broadcast; 0 = not yet sent
     uint32_t _scoreEntryAt     = 0;       // millis() when scoring phase began (for timeout)
+    uint32_t _rosterSentAt     = 0;       // millis() of last end-game MSG_TOTEM_ROSTER re-broadcast
     uint8_t  _scoreSlots[PlayerDefs::MAX_PLAYER_ID][GameDefaults::MAX_WINNER_VARS * 4];
 
     // ---- Helpers ----

--- a/src/radio/LightAir_Radio.cpp
+++ b/src/radio/LightAir_Radio.cpp
@@ -227,8 +227,17 @@ void LightAir_Radio::processPacket(const RadioPacket& pkt, int8_t rssi) {
         _typeId    != RadioTypeId::UNIVERSAL &&
         pkt.typeId != _typeId) return;
 
-    // 3. Flood relay: re-broadcast if not seen before
-    if (pkt.resend > 0 && !isDuplicate(pkt.senderId, pkt.timestamp)) {
+    // 3. Flood relay + de-duplication.
+    // A flood packet (resend > 0) is relayed by every receiver, so the same
+    // logical broadcast (identical senderId + timestamp) arrives here once per
+    // relaying neighbour.  Deliver it only the first time: once seen, drop the
+    // packet entirely (no re-relay, no second delivery).  This keeps counters
+    // driven by broadcast events (kills, flag captures, presence, …) from being
+    // incremented multiple times for a single event.  Legitimate periodic
+    // broadcasts are unaffected: each carries a fresh millis() timestamp, so
+    // they never collide with one another in the dedup ring.
+    if (pkt.resend > 0) {
+        if (isDuplicate(pkt.senderId, pkt.timestamp)) return;
         recordDedup(pkt.senderId, pkt.timestamp);
         RadioPacket relay = pkt;
         relay.resend--;

--- a/src/radio/LightAir_RadioESPNow.cpp
+++ b/src/radio/LightAir_RadioESPNow.cpp
@@ -85,7 +85,16 @@ void LightAir_RadioESPNow::onRecv(const uint8_t* mac_addr,
     LightAir_RadioESPNow* self = _instance;
     if (!self || len <= 0 || len > ESPNOW_MAX_PKT_LEN) return;
 
-    int8_t rssi = 0;  // rx_ctrl not available in ESP-IDF 4.x callback
+    // ESP-IDF 4.x's esp_now_recv_cb_t carries no rx_ctrl, but the driver's
+    // internal RX buffer still places a wifi_promiscuous_pkt_t header right
+    // before the ESP-NOW payload (39 = sizeof the ESP-NOW action-frame
+    // header). Same offset trick the legacy totem firmware used to recover
+    // real RSSI on this core; without it rssi reads as a constant 0 dBm and
+    // every proximity gate in the rulesets (NEAR_*_RSSI / FLAG_RSSI_*) is
+    // effectively disabled.
+    const wifi_promiscuous_pkt_t* promiscuous_pkt =
+        (const wifi_promiscuous_pkt_t*)(data - sizeof(wifi_pkt_rx_ctrl_t) - 39);
+    int8_t rssi = (int8_t)promiscuous_pkt->rx_ctrl.rssi;
 #endif
 
     taskENTER_CRITICAL(&self->_mux);


### PR DESCRIPTION
1. The RSSI gate to limit totem range was skipped, as it seems in  ESP-IDF 4.4 the RSSI is not correctly recovered from the messages, instead it should be read with an offset trick from the pointer to a single message (Thank You Marce Ferra!)
2. Due to a re-send of flooding packets, as the one used to score flag points, the flag counter was repeatedly added even with only one flag taken. Now it should be fixed.
3. Totem actually de-inizialized at the end of the game, but then immediately were re-initialized by the same projectors during the roster phase. Should be fied now.