### PR TITLE
Fix totem over-range and flag-not-restored; fix flood double-count

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -73,12 +73,10 @@ constexpr uint8_t MSG_BASE_BEACON   = 0x56;
 // Reply (0x59): enemy-team player picking up the flag.
 constexpr uint8_t MSG_FLAG_BEACON   = 0x58;
 
-// Broadcast flood by flag carrier when shot — flag returns to its totem.
-// payload[0] = flagTeam (0=O, 1=X).  No reply expected.
+// Reserved (retired): flag drop/score is now carried by MSG_FLAG_EVENT
+// sub-types FlagEvent::DROPPED / FlagEvent::SCORED, which both the Flag
+// ruleset and FlagTotem already use.  Do not reuse these byte values.
 constexpr uint8_t MSG_FLAG_RETURN   = 0x5A;
-
-// Broadcast flood by flag carrier when scoring — flag returns to its totem.
-// payload[0] = flagTeam (0=O, 1=X).  No reply expected.
 constexpr uint8_t MSG_FLAG_SCORE    = 0x5C;
 
 // BONUS totem beacon (new role-based architecture). payload[0] = 0 when ready.
@@ -131,6 +129,18 @@ constexpr uint8_t MSG_TOTEM_BEACON  = 0xF0;
 constexpr uint8_t MSG_TOTEM_ROSTER  = 0xF2;
 
 } // namespace RadioMsg
+
+// ---------------------------------------------------------------
+// FlagEvent — payload[0] sub-types of MSG_FLAG_EVENT (0x50).
+// Shared by the Flag ruleset (broadcaster) and FlagTotem (listener)
+// so both agree on the flag pickup/score/drop protocol.
+//   payload[0] = FlagEvent sub-type; payload[1] = flag's owning team (0=O,1=X).
+// ---------------------------------------------------------------
+namespace FlagEvent {
+    constexpr uint8_t TAKEN   = 1;  // a player picked up the flag
+    constexpr uint8_t DROPPED = 2;  // carrier was shot; flag returns home
+    constexpr uint8_t SCORED  = 3;  // flag captured at a base; flag returns home
+}
 
 // ---------------------------------------------------------------
 // Hardware identity — stored in NVS to select player vs totem

--- a/src/radio/LightAir_Radio.cpp
+++ b/src/radio/LightAir_Radio.cpp
@@ -79,18 +79,20 @@ int LightAir_Radio::findPending(uint8_t replyMsgType, uint32_t timestamp) const 
     return -1;
 }
 
-bool LightAir_Radio::isDuplicate(uint8_t senderId, uint32_t timestamp) const {
+bool LightAir_Radio::isDuplicate(uint8_t senderId, uint32_t timestamp, uint8_t msgType) const {
     for (int i = 0; i < RADIO_DEDUP_WINDOW; i++)
         if (_dedup[i].valid &&
             _dedup[i].senderId  == senderId &&
-            _dedup[i].timestamp == timestamp)
+            _dedup[i].timestamp == timestamp &&
+            _dedup[i].msgType   == msgType)
             return true;
     return false;
 }
 
-void LightAir_Radio::recordDedup(uint8_t senderId, uint32_t timestamp) {
+void LightAir_Radio::recordDedup(uint8_t senderId, uint32_t timestamp, uint8_t msgType) {
     _dedup[_dedupIdx].senderId  = senderId;
     _dedup[_dedupIdx].timestamp = timestamp;
+    _dedup[_dedupIdx].msgType   = msgType;
     _dedup[_dedupIdx].valid     = true;
     _dedupIdx = (_dedupIdx + 1) % RADIO_DEDUP_WINDOW;
 }
@@ -227,18 +229,21 @@ void LightAir_Radio::processPacket(const RadioPacket& pkt, int8_t rssi) {
         _typeId    != RadioTypeId::UNIVERSAL &&
         pkt.typeId != _typeId) return;
 
-    // 3. Flood relay + de-duplication.
-    // A flood packet (resend > 0) is relayed by every receiver, so the same
-    // logical broadcast (identical senderId + timestamp) arrives here once per
-    // relaying neighbour.  Deliver it only the first time: once seen, drop the
-    // packet entirely (no re-relay, no second delivery).  This keeps counters
-    // driven by broadcast events (kills, flag captures, presence, …) from being
-    // incremented multiple times for a single event.  Legitimate periodic
-    // broadcasts are unaffected: each carries a fresh millis() timestamp, so
-    // they never collide with one another in the dedup ring.
+    // 3. De-duplication, then flood relay.
+    // A flood packet is relayed by every receiver, so the same logical message
+    // arrives here multiple times: the original plus one copy per relaying
+    // neighbour, each with a lower resend count.  Deliver (and relay) it exactly
+    // once.  The dedup key is (senderId, timestamp, msgType), which is preserved
+    // across every hop — including the final hop where resend has counted down to
+    // 0 and the packet is otherwise indistinguishable from a non-flood send.
+    // Gating dedup on resend>0 (as before) let that resend==0 tail slip through
+    // and be delivered a second time, double-counting broadcast-driven counters
+    // (e.g. flag captures, ending the game early).  Legitimate periodic
+    // broadcasts are unaffected: each carries a fresh millis() timestamp.
+    if (isDuplicate(pkt.senderId, pkt.timestamp, pkt.msgType)) return;
+    recordDedup(pkt.senderId, pkt.timestamp, pkt.msgType);
+
     if (pkt.resend > 0) {
-        if (isDuplicate(pkt.senderId, pkt.timestamp)) return;
-        recordDedup(pkt.senderId, pkt.timestamp);
         RadioPacket relay = pkt;
         relay.resend--;
         sendRaw(kBroadcastMac, relay);

--- a/src/radio/LightAir_Radio.h
+++ b/src/radio/LightAir_Radio.h
@@ -11,7 +11,7 @@
 // ----------------------------------------------------------------
 #define RADIO_MAX_PAYLOAD  237  // max bytes in payload[] (250 ESP-NOW limit − 13 header)
 #define RADIO_MAX_PENDING  10   // max sent msgs awaiting reply
-#define RADIO_DEDUP_WINDOW 16   // flood-relay dedup history depth
+#define RADIO_DEDUP_WINDOW 32   // flood-relay dedup history depth
 
 // ----------------------------------------------------------------
 // Packet field sentinels
@@ -190,8 +190,11 @@ private:
     };
     PendingMsg _pending[RADIO_MAX_PENDING];
 
-    // ---- deduplication ring for flood relay ----
-    struct DedupEntry { uint8_t senderId; uint32_t timestamp; bool valid; };
+    // ---- deduplication ring ----
+    // Keyed on (senderId, timestamp, msgType): a logical message keeps the same
+    // key across every flood hop, while two distinct messages a sender emits in
+    // the same millisecond differ by msgType and are not confused.
+    struct DedupEntry { uint8_t senderId; uint32_t timestamp; uint8_t msgType; bool valid; };
     DedupEntry _dedup[RADIO_DEDUP_WINDOW];
     uint8_t    _dedupIdx;
 
@@ -202,7 +205,7 @@ private:
     bool sendRaw(const uint8_t mac[6], const RadioPacket& pkt);
     bool storePending(const RadioPacket& pkt);
     int  findPending(uint8_t replyMsgType, uint32_t timestamp) const;
-    bool isDuplicate(uint8_t senderId, uint32_t timestamp) const;
-    void recordDedup(uint8_t senderId, uint32_t timestamp);
+    bool isDuplicate(uint8_t senderId, uint32_t timestamp, uint8_t msgType) const;
+    void recordDedup(uint8_t senderId, uint32_t timestamp, uint8_t msgType);
     void processPacket(const RadioPacket& pkt, int8_t rssi);  // classify and add to _report
 };

--- a/src/rulesets/GameFlag.cpp
+++ b/src/rulesets/GameFlag.cpp
@@ -89,10 +89,12 @@ enum ReplySubType : uint8_t {
 };
 
 // ---- Flag event sub-types ----
+// Aliased to the shared FlagEvent constants (config.h) so the broadcaster here
+// and the FlagTotem listener can never drift out of sync.
 enum FlagEventType : uint8_t {
-    FEVENT_TAKEN   = 1,
-    FEVENT_DROPPED = 2,
-    FEVENT_SCORED  = 3,
+    FEVENT_TAKEN   = FlagEvent::TAKEN,
+    FEVENT_DROPPED = FlagEvent::DROPPED,
+    FEVENT_SCORED  = FlagEvent::SCORED,
 };
 
 // ---- Proximity thresholds ----

--- a/src/totem-rulesets/BaseTotem.cpp
+++ b/src/totem-rulesets/BaseTotem.cpp
@@ -56,8 +56,14 @@ public:
     }
 
     void onMessage(const RadioPacket& msg, LightAir_TotemOutput& out) override {
-        // Accept player reply to our beacon only.
+        // Accept a player's *intentional* respawn reply to our beacon only.
+        // The reply carries subType = team+1 (payload[0] >= 1); the player sends
+        // it solely when it is within its own RSSI proximity gate of this base.
+        // Reject the empty 0x57 auto-reply the GameRunner emits for every beacon
+        // (payloadLen == 0) — it carries no distance information and would make
+        // the base react to any player anywhere in radio range.
         if (msg.msgType != MSG_BASE_BEACON + 1) return;
+        if (msg.payloadLen == 0 || msg.payload[0] == 0) return;
         uint8_t r, g, b;
         if (_team == 0xFF) {
             // Teamless base: wipe in the respawning player's personal colour.

--- a/src/totem-rulesets/FlagTotem.cpp
+++ b/src/totem-rulesets/FlagTotem.cpp
@@ -13,30 +13,29 @@
 //   onActivate() : enters FLAG_IN; shows Idle background (team colour glow).
 //   update()     : in FLAG_IN, broadcasts MSG_FLAG_BEACON every
 //                  FLAG_BEACON_INTERVAL_MS.
-//   onMessage()  :
-//     FLAG_IN  — on enemy-player reply (0x59) → FLAG_OUT + FlagMissing anim
-//                (double-blink, team colour) + FlagTaken flash (picker's colour).
-//     FLAG_OUT — on MSG_FLAG_RETURN or MSG_FLAG_SCORE flood matching our
-//                team → FLAG_IN + FlagReturn anim (flash, team colour).
+//   onMessage()  : driven entirely by MSG_FLAG_EVENT broadcasts from players
+//                  (payload[1] == _team selects events for this flag):
+//     FlagEvent::TAKEN   — FLAG_IN → FLAG_OUT + FlagMissing anim (team colour)
+//                          + FlagTaken flash (picker's colour).
+//     FlagEvent::DROPPED — FLAG_OUT → FLAG_IN + FlagReturn anim (flash).
+//     FlagEvent::SCORED  — FLAG_OUT → FLAG_IN + FlagReturn anim (flash).
 //   reset()      : returns to FLAG_IN; clears timer.
 //
 // Two singletons: flagO (owns the O flag) and flagX (owns the X flag).
 // The team is fixed at construction and encodes which team's flag this is.
 //
-// Flag pickup protocol
-//   A player who spots MSG_FLAG_BEACON(state=IN) from the enemy flag with
-//   sufficient RSSI sends a reply (0x59) to claim the flag.  The flag
-//   totem detects this reply and transitions to FLAG_OUT.
-//
-// Flag return protocol
-//   MSG_FLAG_RETURN : broadcast flood from carrier who was shot.
-//   MSG_FLAG_SCORE  : broadcast flood from carrier who scored.
-//   Both carry payload[0] = flagTeam; only packets matching _team are acted on.
+// Flag protocol (must stay in sync with the Flag ruleset, GameFlag.cpp)
+//   The totem reacts only to MSG_FLAG_EVENT broadcasts a player emits when it
+//   actually picks up, scores, or drops a flag — and the player emits those
+//   only once it is within its own RSSI proximity gate of the flag/base.  The
+//   totem therefore inherits that proximity gate and never reacts to a distant
+//   player.  (It must NOT react to the empty 0x59 auto-reply the GameRunner
+//   sends for every beacon, which carries no distance information.)
 // ================================================================
 
 using RadioMsg::MSG_FLAG_BEACON;
-using RadioMsg::MSG_FLAG_RETURN;
-using RadioMsg::MSG_FLAG_SCORE;
+using RadioMsg::MSG_FLAG_EVENT;
+namespace FE = FlagEvent;
 
 static constexpr uint32_t FLAG_BEACON_INTERVAL_MS = 500;
 static constexpr uint8_t  FLAG_STATE_IN  = 0;
@@ -82,9 +81,17 @@ public:
     }
 
     void onMessage(const RadioPacket& msg, LightAir_TotemOutput& out) override {
+        // Only MSG_FLAG_EVENT broadcasts drive this totem; payload[1] selects
+        // events for the flag this totem owns.  Player-side RSSI gating means
+        // these only fire when a player is actually at the flag/base.
+        if (msg.msgType != MSG_FLAG_EVENT) return;
+        if (msg.payloadLen < 2)            return;
+        if (msg.payload[1] != _team)       return;  // not our flag's event
+
+        const uint8_t sub = msg.payload[0];
+
         if (_state == FLAG_STATE_IN) {
-            // Enemy-team player replies to our beacon → flag picked up.
-            if (msg.msgType == MSG_FLAG_BEACON + 1 && msg.team != _team) {
+            if (sub == FE::TAKEN) {
                 _state = FLAG_STATE_OUT;
                 uint8_t r, g, b;
                 teamColor(r, g, b);
@@ -100,11 +107,8 @@ public:
             return;
         }
 
-        // FLAG_STATE_OUT: wait for return or score broadcast.
-        if (msg.payloadLen < 1) return;
-        if (msg.payload[0] != _team) return;  // not our flag's event
-
-        if (msg.msgType == MSG_FLAG_RETURN || msg.msgType == MSG_FLAG_SCORE) {
+        // FLAG_STATE_OUT: a drop (carrier shot) or a score returns the flag home.
+        if (sub == FE::DROPPED || sub == FE::SCORED) {
             returnFlag(out);
         }
     }


### PR DESCRIPTION
Three distinct bugs surfaced once RSSI gating was looked at end-to-end:

1) Totems react far beyond the RSSI gate. The gates live player-side, but
   the totems were reacting to the GameRunner's empty 0x57/0x59 auto-reply
   that every player emits for any beacon it has no rule for — ungated by
   distance. BaseTotem now ignores the empty auto-reply (payloadLen==0),
   matching CPTotem, so it only reacts to the intentional respawn reply a
   player sends when inside its NEAR_RSSI gate. FlagTotem is driven entirely
   by MSG_FLAG_EVENT (the player only broadcasts it on a real, RSSI-gated
   pickup/score/drop), so it inherits the player's proximity gate.

2) Enemy flag never restored after scoring. FlagTotem waited for
   MSG_FLAG_RETURN/MSG_FLAG_SCORE, which the player never sends — it
   broadcasts MSG_FLAG_EVENT with FlagEvent sub-types. The totem stayed
   FLAG_OUT until power-cycled. FlagTotem now reacts to
   FlagEvent::TAKEN/DROPPED/SCORED; sub-types are shared in config.h so
   ruleset and totem cannot drift.

3) Game ends early (e.g. at 2 captures with EndPoints=3). A flood's final
   relay arrives with resend==0, which bypassed the resend>0-gated dedup and
   was delivered a second time, double-counting myTeamPoints. Dedup now runs
   for every packet, keyed on (senderId,timestamp,msgType). The added msgType
   also stops two distinct broadcasts sent in the same millisecond (e.g.
   MSG_END_GAME + MSG_TOTEM_ROSTER) from colliding in the dedup ring.
