### PR TITLE
Fix Flag scoring to require own flag in, tighten base/flag RSSI range

### DIFF
--- a/src/rulesets/GameFlag.cpp
+++ b/src/rulesets/GameFlag.cpp
@@ -98,8 +98,8 @@ enum FlagEventType : uint8_t {
 };
 
 // ---- Proximity thresholds ----
-static constexpr int8_t  NEAR_RSSI_THRESHOLD = -60;  // ~2 m: base proximity (respawn + scoring)
-static constexpr int8_t  FLAG_RSSI_THRESHOLD  = -65;  // ~3-4 m: flag pickup zone
+static constexpr int8_t  NEAR_RSSI_THRESHOLD = -57;  // ~2 m: base proximity (respawn + scoring)
+static constexpr int8_t  FLAG_RSSI_THRESHOLD  = -62;  // ~3-4 m: flag pickup zone
 static constexpr uint32_t HIT_IMMUNITY_MS     = 3000;
 
 // ---- Config variables ----
@@ -501,7 +501,9 @@ static void doInGame(const InputReport& inp, const RadioReport& radio,
     }
 
     // ---- Flag score ----
-    // Score when carrying and we reach a friendly BASE.
+    // Score when carrying and we reach a friendly BASE — but only if our own
+    // flag is currently in (not taken by the enemy). Returning the enemy's
+    // flag while ours is away must not score.
     if (hasEnemyFlag) {
         for (uint8_t e = 0; e < radio.count; e++) {
             const RadioEvent& ev = radio.events[e];
@@ -510,6 +512,7 @@ static void doInGame(const InputReport& inp, const RadioReport& radio,
             if (ev.packet.payloadLen < 1)                             continue;
             if (ev.packet.payload[0] != myTeam)                      continue;
             if (ev.rssi           <  NEAR_RSSI_THRESHOLD)             continue;
+            if (myFlagCarrierId   != 0xFF)                            continue;
 
             flagsCaptured++;
             points             = flagsCaptured;

--- a/src/rulesets/GameKingOfHill.cpp
+++ b/src/rulesets/GameKingOfHill.cpp
@@ -84,7 +84,7 @@ static constexpr uint8_t CP_TEAM_NONE   = 0xFF;
 
 // ---- RSSI proximity thresholds ----
 static constexpr int8_t  NEAR_CP_RSSI    = -65;  // ~3 m indoors; CP presence
-static constexpr int8_t  NEAR_BASE_RSSI  = -60;  // ~2 m indoors; BASE respawn
+static constexpr int8_t  NEAR_BASE_RSSI  = -57;  // ~2 m indoors; BASE respawn
 static constexpr uint32_t HIT_IMMUNITY_MS = 3000;
 
 // ---- Config variables ----

--- a/src/rulesets/GameTeams.cpp
+++ b/src/rulesets/GameTeams.cpp
@@ -73,8 +73,8 @@ enum ReplySubType : uint8_t {
 
 // ---- RSSI proximity threshold ----
 // Packets from a BASE with RSSI below this value are ignored for respawn.
-// -60 dBm corresponds to approximately 2 m indoors at 2.4 GHz.
-static constexpr int8_t  NEAR_RSSI_THRESHOLD = -60;
+// -57 dBm corresponds to approximately 2 m indoors at 2.4 GHz.
+static constexpr int8_t  NEAR_RSSI_THRESHOLD = -57;
 static constexpr uint32_t HIT_IMMUNITY_MS    = 3000;
 
 // ---- Config variables ----

--- a/src/rulesets/GameUpkeep.cpp
+++ b/src/rulesets/GameUpkeep.cpp
@@ -89,7 +89,7 @@ static constexpr uint8_t CP_TEAM_NONE = 0xFF;  // teamless
 
 // ---- RSSI proximity thresholds ----
 static constexpr int8_t  NEAR_CP_RSSI    = -65;  // ~3 m indoors for CP presence
-static constexpr int8_t  NEAR_BASE_RSSI  = -60;  // ~2 m indoors for BASE respawn
+static constexpr int8_t  NEAR_BASE_RSSI  = -57;  // ~2 m indoors for BASE respawn
 static constexpr uint32_t HIT_IMMUNITY_MS = 3000;
 
 // ---- Config variables ----


### PR DESCRIPTION
- GameFlag.cpp: a carried enemy flag can no longer be scored unless the scoring player's own flag is currently at home (myFlagCarrierId == 0xFF) — returning the enemy flag while your own flag is away no longer awards a point.
- Raise base-proximity RSSI thresholds by 3 dB (-60 -> -57) in GameFlag.cpp, GameTeams.cpp, GameUpkeep.cpp, GameKingOfHill.cpp, and the flag-pickup threshold in GameFlag.cpp (-65 -> -62), to further limit totem detection range.
