### PR TITLE
Fixing flag radio messages

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -87,7 +87,21 @@ constexpr uint8_t MSG_BONUS_BEACON  = 0x5E;
 // Reply (0x61): player claims malus.
 constexpr uint8_t MSG_MALUS_BEACON  = 0x60;
 
-// Next available in 0x50 block: 0x62
+// Player → BASE totem unicast: "I am respawning at you" (even; no relay).
+// payload[0] = myTeam+1 (non-zero sanity marker). senderId = the player and
+// team = the player's team (both auto-stamped by sendTo). Replaces the old
+// odd-reply respawn signal, which processPacket() silently dropped because the
+// base's beacon (broadcast) never stored a pending entry to match it against.
+constexpr uint8_t MSG_RESPAWN_NOTIFY = 0x62;
+
+// Player → FLAG totem unicast: flag state change for this specific flag
+// (even; no relay). payload[0] = FlagEvent sub-type (TAKEN/DROPPED/SCORED);
+// senderId = the player (used for the pickup flash colour). Unicast targets
+// the one flag totem the carrier took, so multiple flags per team work
+// correctly. MSG_FLAG_EVENT remains a broadcast for player-to-player sync.
+constexpr uint8_t MSG_FLAG_NOTIFY    = 0x64;
+
+// Next available in 0x50 block: 0x66
 
 // ── 0xA0 block: infrastructure ──────────────────────────────────
 // Sent with typeId == UNIVERSAL (0x0000); not game-scoped.

--- a/src/config.h
+++ b/src/config.h
@@ -94,14 +94,28 @@ constexpr uint8_t MSG_MALUS_BEACON  = 0x60;
 // base's beacon (broadcast) never stored a pending entry to match it against.
 constexpr uint8_t MSG_RESPAWN_NOTIFY = 0x62;
 
-// Player → FLAG totem unicast: flag state change for this specific flag
-// (even; no relay). payload[0] = FlagEvent sub-type (TAKEN/DROPPED/SCORED);
-// senderId = the player (used for the pickup flash colour). Unicast targets
-// the one flag totem the carrier took, so multiple flags per team work
-// correctly. MSG_FLAG_EVENT remains a broadcast for player-to-player sync.
+// Player → FLAG totem: flag state change for one specific flag totem.
+// BROADCAST with mesh relay (resend>0): drop/score happen away from the
+// flag (the carrier may be several hops out of the totem's radio range), so
+// this must be able to reach it across relays — a plain unicast cannot be
+// mesh-relayed. payload[0] = FlagEvent sub-type (TAKEN/DROPPED/SCORED);
+// payload[1] = target flag totem's id (the carrier remembers it from the
+// beacon it took). The totem reacts only when payload[1] == its own id, so
+// multiple flags per team work and other totems ignore it. senderId = the
+// carrier (used for the pickup flash colour). MSG_FLAG_EVENT stays a
+// separate broadcast for player-to-player carrier/point sync.
 constexpr uint8_t MSG_FLAG_NOTIFY    = 0x64;
 
-// Next available in 0x50 block: 0x66
+// Player → CP totem unicast: "I am present at you" (even; no relay).
+// Presence is RSSI-gated at the CP, so the player is in direct range — a
+// unicast addressed to the CP suffices (no hops). payload[0] = myTeam+1
+// (1..16; 0 reserved/ignored). Replaces the old odd-reply presence signal,
+// which processPacket() silently dropped (same bug as base respawn),
+// breaking CP ownership detection. CPTotem folds payload[0] into its
+// presence mask exactly as it did the old reply subType.
+constexpr uint8_t MSG_CP_NOTIFY      = 0x66;
+
+// Next available in 0x50 block: 0x68
 
 // ── 0xA0 block: infrastructure ──────────────────────────────────
 // Sent with typeId == UNIVERSAL (0x0000); not game-scoped.

--- a/src/config.h
+++ b/src/config.h
@@ -49,7 +49,16 @@ constexpr uint8_t MSG_POINT_REPORT  = 0x14;
 // Messages that travel between a player and a totem (not player→player).
 
 // Flag state change broadcast: pickup / capture / drop (Flag game).
-// payload[0] = FlagEventType; no meaningful reply expected.
+// Flooded broadcast that serves BOTH duties for one event (one flood, not two):
+//   payload[0] = FlagEventType (TAKEN/DROPPED/SCORED).
+//   payload[1] = flag's owning team (0=O, 1=X) — players use [0]/[1] to sync
+//                carrier state and team points.
+//   payload[2] = target flag totem's id (the carrier remembers it from the
+//                beacon it took). The owning FLAG totem animates only when
+//                [2] == its own id, so the right flag reacts (multiple flags
+//                per team work) and the hopped broadcast still reaches it when
+//                the carrier drops/scores out of the totem's direct range.
+// No meaningful reply expected.
 constexpr uint8_t MSG_FLAG_EVENT    = 0x50;
 
 // Control-point beacon broadcast by CP totem every 2 s (Upkeep, KingOfHill).
@@ -94,18 +103,6 @@ constexpr uint8_t MSG_MALUS_BEACON  = 0x60;
 // base's beacon (broadcast) never stored a pending entry to match it against.
 constexpr uint8_t MSG_RESPAWN_NOTIFY = 0x62;
 
-// Player → FLAG totem: flag state change for one specific flag totem.
-// BROADCAST with mesh relay (resend>0): drop/score happen away from the
-// flag (the carrier may be several hops out of the totem's radio range), so
-// this must be able to reach it across relays — a plain unicast cannot be
-// mesh-relayed. payload[0] = FlagEvent sub-type (TAKEN/DROPPED/SCORED);
-// payload[1] = target flag totem's id (the carrier remembers it from the
-// beacon it took). The totem reacts only when payload[1] == its own id, so
-// multiple flags per team work and other totems ignore it. senderId = the
-// carrier (used for the pickup flash colour). MSG_FLAG_EVENT stays a
-// separate broadcast for player-to-player carrier/point sync.
-constexpr uint8_t MSG_FLAG_NOTIFY    = 0x64;
-
 // Player → CP totem unicast: "I am present at you" (even; no relay).
 // Presence is RSSI-gated at the CP, so the player is in direct range — a
 // unicast addressed to the CP suffices (no hops). payload[0] = myTeam+1
@@ -113,9 +110,9 @@ constexpr uint8_t MSG_FLAG_NOTIFY    = 0x64;
 // which processPacket() silently dropped (same bug as base respawn),
 // breaking CP ownership detection. CPTotem folds payload[0] into its
 // presence mask exactly as it did the old reply subType.
-constexpr uint8_t MSG_CP_NOTIFY      = 0x66;
+constexpr uint8_t MSG_CP_NOTIFY      = 0x64;
 
-// Next available in 0x50 block: 0x68
+// Next available in 0x50 block: 0x66
 
 // ── 0xA0 block: infrastructure ──────────────────────────────────
 // Sent with typeId == UNIVERSAL (0x0000); not game-scoped.

--- a/src/game/LightAir_GameSetupMenu.cpp
+++ b/src/game/LightAir_GameSetupMenu.cpp
@@ -319,9 +319,13 @@ MenuResult LightAir_GameSetupMenu::runWaiter() {
     _display.flush();
 
     while (true) {
-        // Periodic presence broadcast so DM and peers discover this device.
+        // Periodic heartbeat so DM and peers discover this device.  Before
+        // accepting we send MSG_ROSTER (presence only, not counted by the DM);
+        // once joined we repeat MSG_JOIN so the DM reliably and repeatedly
+        // hears the accept even if the one-shot join packet was lost.
         if (millis() >= nextBroadcast) {
-            _radio.broadcast(GameDefaults::MSG_ROSTER, nullptr, 0, 2);
+            _radio.broadcast(joined ? GameDefaults::MSG_JOIN
+                                    : GameDefaults::MSG_ROSTER, nullptr, 0, 2);
             nextBroadcast = millis() + GameDefaults::PRESTART_BROADCAST_MS;
         }
 
@@ -870,20 +874,25 @@ MenuResult LightAir_GameSetupMenu::runPreStart() {
     renderSummary(vScroll);
 
     while (true) {
-        // Broadcast MSG_ROSTER periodically so other devices discover us.
+        // Periodically re-broadcast the roster heartbeat AND the config blob so
+        // any player that missed the initial config (lossy/unacked ESP-NOW
+        // broadcast, momentarily full receive queue) eventually catches a copy.
+        // game_apply_config() is idempotent, so repeats are harmless.
         if (millis() >= nextBroadcast) {
             _radio.broadcast(GameDefaults::MSG_ROSTER, nullptr, 0, 2);
+            if (len > 0) _radio.broadcast(_msgType, blob, len, 2);
             nextBroadcast = millis() + GameDefaults::PRESTART_BROADCAST_MS;
         }
 
-        // Collect MSG_ROSTER and MSG_JOIN; refresh summary when player count grows.
+        // Count MSG_JOIN only; refresh summary when accepted-player count grows.
+        // MSG_ROSTER is presence-only and is NOT counted — only players that
+        // actually accepted (MSG_JOIN) appear in the matchup tally.
         const RadioReport& rep = _radio.poll();
         uint8_t prevCount = _seenCount;
         for (uint8_t i = 0; i < rep.count; i++) {
             const RadioEvent& ev = rep.events[i];
             if (ev.type != RadioEventType::MessageReceived) continue;
-            if (ev.packet.msgType != GameDefaults::MSG_ROSTER &&
-                ev.packet.msgType != GameDefaults::MSG_JOIN) continue;
+            if (ev.packet.msgType != GameDefaults::MSG_JOIN) continue;
             recordSeen(ev.packet.senderId);
         }
         if (_seenCount != prevCount)

--- a/src/rulesets/GameFlag.cpp
+++ b/src/rulesets/GameFlag.cpp
@@ -400,9 +400,11 @@ static void onShone(LightAir_DisplayCtrl& disp, GameOutput& out) {
     if (hasEnemyFlag) {
         uint8_t pl[2] = { FEVENT_DROPPED, enemyTeam() };
         out.radio.broadcast(MSG_FLAG_EVENT, pl, 2, 2);
-        // Unicast the flag totem we took so it returns home (animate).
-        uint8_t fn[1] = { FEVENT_DROPPED };
-        out.radio.sendTo(enemyFlagTotemId, RadioMsg::MSG_FLAG_NOTIFY, fn, 1);
+        // Notify the flag totem we took so it returns home (animate).
+        // Broadcast with hops + target id: we are shot away from the flag,
+        // so the totem may be several hops out of direct range.
+        uint8_t fn[2] = { FEVENT_DROPPED, enemyFlagTotemId };
+        out.radio.broadcast(RadioMsg::MSG_FLAG_NOTIFY, fn, 2, 2);
         enemyFlagTotemId   = 0xFF;
         hasEnemyFlag       = false;
         enemyFlagCarrierId = 0xFF;
@@ -500,9 +502,11 @@ static void doInGame(const InputReport& inp, const RadioReport& radio,
             enemyFlagTotemId   = ev.packet.senderId;  // remember which flag totem we took
             uint8_t pl[2] = { FEVENT_TAKEN, enemyTeam() };
             out.radio.broadcast(MSG_FLAG_EVENT, pl, 2, 2);
-            // Unicast the specific flag totem so it (and only it) animates.
-            uint8_t fn[1] = { FEVENT_TAKEN };
-            out.radio.sendTo(enemyFlagTotemId, RadioMsg::MSG_FLAG_NOTIFY, fn, 1);
+            // Notify the specific flag totem so it (and only it) animates.
+            // Broadcast with hops + target id so it reaches the totem even if
+            // we are several hops out of its direct range.
+            uint8_t fn[2] = { FEVENT_TAKEN, enemyFlagTotemId };
+            out.radio.broadcast(RadioMsg::MSG_FLAG_NOTIFY, fn, 2, 2);
             out.ui.trigger(LightAir_UICtrl::UIEvent::FlagGain);   // "FLAG +"
             if (uiCtrl) uiCtrl->setBackground(kFlagCarryBg);
             disp.showMessage("YOU HAVE FLAG", 0);
@@ -531,9 +535,11 @@ static void doInGame(const InputReport& inp, const RadioReport& radio,
             enemyFlagCarrierId = 0xFF;
             uint8_t pl[2] = { FEVENT_SCORED, enemyTeam() };
             out.radio.broadcast(MSG_FLAG_EVENT, pl, 2, 2);
-            // Unicast the flag totem we took so it returns home (animate).
-            uint8_t fn[1] = { FEVENT_SCORED };
-            out.radio.sendTo(enemyFlagTotemId, RadioMsg::MSG_FLAG_NOTIFY, fn, 1);
+            // Notify the flag totem we took so it returns home (animate).
+            // Broadcast with hops + target id: we score at our base, away from
+            // the flag, so the totem may be several hops out of direct range.
+            uint8_t fn[2] = { FEVENT_SCORED, enemyFlagTotemId };
+            out.radio.broadcast(RadioMsg::MSG_FLAG_NOTIFY, fn, 2, 2);
             enemyFlagTotemId   = 0xFF;
             out.ui.trigger(LightAir_UICtrl::UIEvent::FlagGain);   // "FLAG +"
             if (uiCtrl) uiCtrl->clearBackground();

--- a/src/rulesets/GameFlag.cpp
+++ b/src/rulesets/GameFlag.cpp
@@ -398,13 +398,11 @@ static bool endPointsReached(const InputReport&, const RadioReport&) {
 // ---- Transition actions ----
 static void onShone(LightAir_DisplayCtrl& disp, GameOutput& out) {
     if (hasEnemyFlag) {
-        uint8_t pl[2] = { FEVENT_DROPPED, enemyTeam() };
-        out.radio.broadcast(MSG_FLAG_EVENT, pl, 2, 2);
-        // Notify the flag totem we took so it returns home (animate).
-        // Broadcast with hops + target id: we are shot away from the flag,
-        // so the totem may be several hops out of direct range.
-        uint8_t fn[2] = { FEVENT_DROPPED, enemyFlagTotemId };
-        out.radio.broadcast(RadioMsg::MSG_FLAG_NOTIFY, fn, 2, 2);
+        // One flooded broadcast does both jobs: payload[0]/[1] sync players,
+        // payload[2] = the flag totem we took so it (and only it) returns home.
+        // We are shot away from the flag, so hops carry it across the mesh.
+        uint8_t pl[3] = { FEVENT_DROPPED, enemyTeam(), enemyFlagTotemId };
+        out.radio.broadcast(MSG_FLAG_EVENT, pl, 3, 2);
         enemyFlagTotemId   = 0xFF;
         hasEnemyFlag       = false;
         enemyFlagCarrierId = 0xFF;
@@ -500,13 +498,11 @@ static void doInGame(const InputReport& inp, const RadioReport& radio,
             hasEnemyFlag       = true;
             enemyFlagCarrierId = 0x01;   // mark taken locally; other players update via broadcast
             enemyFlagTotemId   = ev.packet.senderId;  // remember which flag totem we took
-            uint8_t pl[2] = { FEVENT_TAKEN, enemyTeam() };
-            out.radio.broadcast(MSG_FLAG_EVENT, pl, 2, 2);
-            // Notify the specific flag totem so it (and only it) animates.
-            // Broadcast with hops + target id so it reaches the totem even if
-            // we are several hops out of its direct range.
-            uint8_t fn[2] = { FEVENT_TAKEN, enemyFlagTotemId };
-            out.radio.broadcast(RadioMsg::MSG_FLAG_NOTIFY, fn, 2, 2);
+            // One flooded broadcast does both jobs: payload[0]/[1] sync
+            // players, payload[2] = this flag totem so it (and only it)
+            // animates the pickup.
+            uint8_t pl[3] = { FEVENT_TAKEN, enemyTeam(), enemyFlagTotemId };
+            out.radio.broadcast(MSG_FLAG_EVENT, pl, 3, 2);
             out.ui.trigger(LightAir_UICtrl::UIEvent::FlagGain);   // "FLAG +"
             if (uiCtrl) uiCtrl->setBackground(kFlagCarryBg);
             disp.showMessage("YOU HAVE FLAG", 0);
@@ -533,13 +529,11 @@ static void doInGame(const InputReport& inp, const RadioReport& radio,
             myTeamPoints++;
             hasEnemyFlag       = false;
             enemyFlagCarrierId = 0xFF;
-            uint8_t pl[2] = { FEVENT_SCORED, enemyTeam() };
-            out.radio.broadcast(MSG_FLAG_EVENT, pl, 2, 2);
-            // Notify the flag totem we took so it returns home (animate).
-            // Broadcast with hops + target id: we score at our base, away from
-            // the flag, so the totem may be several hops out of direct range.
-            uint8_t fn[2] = { FEVENT_SCORED, enemyFlagTotemId };
-            out.radio.broadcast(RadioMsg::MSG_FLAG_NOTIFY, fn, 2, 2);
+            // One flooded broadcast does both jobs: payload[0]/[1] sync
+            // players, payload[2] = the flag totem we took so it returns home.
+            // We score at our base, away from the flag, so hops carry it.
+            uint8_t pl[3] = { FEVENT_SCORED, enemyTeam(), enemyFlagTotemId };
+            out.radio.broadcast(MSG_FLAG_EVENT, pl, 3, 2);
             enemyFlagTotemId   = 0xFF;
             out.ui.trigger(LightAir_UICtrl::UIEvent::FlagGain);   // "FLAG +"
             if (uiCtrl) uiCtrl->clearBackground();

--- a/src/rulesets/GameFlag.cpp
+++ b/src/rulesets/GameFlag.cpp
@@ -132,6 +132,7 @@ static uint32_t litAt[PlayerDefs::MAX_PLAYER_ID];
 static bool     hasEnemyFlag;
 static uint8_t  enemyFlagCarrierId;  // 0xFF = flag available at its totem
 static uint8_t  myFlagCarrierId;     // 0xFF = our flag at home
+static uint8_t  enemyFlagTotemId;    // id of the FLAG totem we took; for unicast notify
 
 static uint8_t  myTeam;      // 0=O, 1=X
 static uint8_t  teamMap[PlayerDefs::MAX_PLAYER_ID];  // per-player team index; filled from config blob
@@ -217,6 +218,7 @@ static void onBegin(LightAir_DisplayCtrl&, LightAir_Radio& radio, LightAir_UICtr
     hasEnemyFlag       = false;
     enemyFlagCarrierId = 0xFF;
     myFlagCarrierId    = 0xFF;
+    enemyFlagTotemId   = 0xFF;
     lastTickAt         = millis();
     triggerWasActive   = false;
     releaseAt          = 0;
@@ -398,6 +400,10 @@ static void onShone(LightAir_DisplayCtrl& disp, GameOutput& out) {
     if (hasEnemyFlag) {
         uint8_t pl[2] = { FEVENT_DROPPED, enemyTeam() };
         out.radio.broadcast(MSG_FLAG_EVENT, pl, 2, 2);
+        // Unicast the flag totem we took so it returns home (animate).
+        uint8_t fn[1] = { FEVENT_DROPPED };
+        out.radio.sendTo(enemyFlagTotemId, RadioMsg::MSG_FLAG_NOTIFY, fn, 1);
+        enemyFlagTotemId   = 0xFF;
         hasEnemyFlag       = false;
         enemyFlagCarrierId = 0xFF;
         out.ui.trigger(LightAir_UICtrl::UIEvent::FlagTaken);  // "FLAG LOST"
@@ -491,8 +497,12 @@ static void doInGame(const InputReport& inp, const RadioReport& radio,
 
             hasEnemyFlag       = true;
             enemyFlagCarrierId = 0x01;   // mark taken locally; other players update via broadcast
+            enemyFlagTotemId   = ev.packet.senderId;  // remember which flag totem we took
             uint8_t pl[2] = { FEVENT_TAKEN, enemyTeam() };
             out.radio.broadcast(MSG_FLAG_EVENT, pl, 2, 2);
+            // Unicast the specific flag totem so it (and only it) animates.
+            uint8_t fn[1] = { FEVENT_TAKEN };
+            out.radio.sendTo(enemyFlagTotemId, RadioMsg::MSG_FLAG_NOTIFY, fn, 1);
             out.ui.trigger(LightAir_UICtrl::UIEvent::FlagGain);   // "FLAG +"
             if (uiCtrl) uiCtrl->setBackground(kFlagCarryBg);
             disp.showMessage("YOU HAVE FLAG", 0);
@@ -521,6 +531,10 @@ static void doInGame(const InputReport& inp, const RadioReport& radio,
             enemyFlagCarrierId = 0xFF;
             uint8_t pl[2] = { FEVENT_SCORED, enemyTeam() };
             out.radio.broadcast(MSG_FLAG_EVENT, pl, 2, 2);
+            // Unicast the flag totem we took so it returns home (animate).
+            uint8_t fn[1] = { FEVENT_SCORED };
+            out.radio.sendTo(enemyFlagTotemId, RadioMsg::MSG_FLAG_NOTIFY, fn, 1);
+            enemyFlagTotemId   = 0xFF;
             out.ui.trigger(LightAir_UICtrl::UIEvent::FlagGain);   // "FLAG +"
             if (uiCtrl) uiCtrl->clearBackground();
             disp.clearTray();
@@ -548,8 +562,13 @@ static void doOutGame(const InputReport&, const RadioReport& radio,
             ev.packet.payload[0] != 0xFF)                         continue;
         if (ev.rssi           <  NEAR_RSSI_THRESHOLD)             continue;
         canRespawn = true;
-        // Notify the BASE totem so it can show a Respawn animation.
-        out.radio.reply(ev.packet, (uint8_t)(myTeam + 1));
+        // Unicast so the specific BASE totem we reached can show a Respawn
+        // animation. payload[0] = myTeam+1 non-zero marker; totem also reads
+        // msg.team / msg.senderId.
+        {
+            uint8_t pl[1] = { (uint8_t)(myTeam + 1) };
+            out.radio.sendTo(ev.packet.senderId, RadioMsg::MSG_RESPAWN_NOTIFY, pl, 1);
+        }
         break;
     }
 }

--- a/src/rulesets/GameKingOfHill.cpp
+++ b/src/rulesets/GameKingOfHill.cpp
@@ -408,8 +408,13 @@ static void doOutGame(const InputReport&, const RadioReport& radio,
         if (ev.packet.payload[0] != 0xFF)                         continue;  // teamless only
         if (ev.rssi            < NEAR_BASE_RSSI)                  continue;
         canRespawn = true;
-        // Reply so the BASE totem shows a Respawn animation in this player's colour.
-        out.radio.reply(ev.packet, (uint8_t)(myTeam + 1));
+        // Unicast so the specific BASE totem we reached shows a Respawn
+        // animation in this player's colour. payload[0] = myTeam+1 non-zero
+        // marker; totem also reads msg.team / msg.senderId.
+        {
+            uint8_t pl[1] = { (uint8_t)(myTeam + 1) };
+            out.radio.sendTo(ev.packet.senderId, RadioMsg::MSG_RESPAWN_NOTIFY, pl, 1);
+        }
         break;
     }
 }

--- a/src/rulesets/GameKingOfHill.cpp
+++ b/src/rulesets/GameKingOfHill.cpp
@@ -300,10 +300,15 @@ static void scanCpBeacons(const RadioReport& radio, LightAir_DisplayCtrl& disp,
             }
         }
 
-        // Reply with our presence so the CP totem can update ownership.
-        // subType = myTeam + 1 (same formula as Upkeep: 1 = slot-0, 2 = slot-1, …).
-        if (sendPresence && ev.rssi >= NEAR_CP_RSSI)
-            out.radio.reply(ev.packet, (uint8_t)(myTeam + 1));
+        // Unicast our presence so the CP totem can update ownership.
+        // payload[0] = myTeam + 1 (same formula as Upkeep: 1 = slot-0, …).
+        // (The old odd-reply was silently dropped by the radio's pending-match
+        // gate.) Presence is RSSI-gated at the CP, so we are in direct range —
+        // no hops needed.
+        if (sendPresence && ev.rssi >= NEAR_CP_RSSI) {
+            uint8_t pl[1] = { (uint8_t)(myTeam + 1) };
+            out.radio.sendTo(ev.packet.senderId, RadioMsg::MSG_CP_NOTIFY, pl, 1);
+        }
     }
 }
 

--- a/src/rulesets/GameTeams.cpp
+++ b/src/rulesets/GameTeams.cpp
@@ -376,9 +376,13 @@ static void doOutGame(const InputReport&, const RadioReport& radio,
             ev.packet.payload[0] != 0xFF)                         continue;
         if (ev.rssi < NEAR_RSSI_THRESHOLD)                        continue;
         canRespawn = true;
-        // Reply so the BASE totem can show a Respawn animation.
-        // subType 1 = team-O, 2 = team-X.
-        out.radio.reply(ev.packet, (uint8_t)(myTeam + 1));
+        // Unicast so the specific BASE totem we reached can show a Respawn
+        // animation. payload[0] = myTeam+1 (1=team-O, 2=team-X) as a non-zero
+        // marker; the totem also reads msg.team / msg.senderId.
+        {
+            uint8_t pl[1] = { (uint8_t)(myTeam + 1) };
+            out.radio.sendTo(ev.packet.senderId, RadioMsg::MSG_RESPAWN_NOTIFY, pl, 1);
+        }
         break;
     }
 }

--- a/src/rulesets/GameUpkeep.cpp
+++ b/src/rulesets/GameUpkeep.cpp
@@ -476,8 +476,13 @@ static void doOutGame(const InputReport&, const RadioReport& radio,
             ev.packet.payload[0] != 0xFF)                         continue;
         if (ev.rssi            < NEAR_BASE_RSSI)                  continue;
         canRespawn = true;
-        // Notify the BASE totem so it can show a Respawn animation.
-        out.radio.reply(ev.packet, (uint8_t)(myTeam + 1));
+        // Unicast so the specific BASE totem we reached can show a Respawn
+        // animation. payload[0] = myTeam+1 non-zero marker; totem also reads
+        // msg.team / msg.senderId.
+        {
+            uint8_t pl[1] = { (uint8_t)(myTeam + 1) };
+            out.radio.sendTo(ev.packet.senderId, RadioMsg::MSG_RESPAWN_NOTIFY, pl, 1);
+        }
         break;
     }
 }

--- a/src/rulesets/GameUpkeep.cpp
+++ b/src/rulesets/GameUpkeep.cpp
@@ -368,10 +368,15 @@ static void scanCpBeacons(const RadioReport& radio, LightAir_DisplayCtrl& disp,
             }
         }
 
-        // Reply with our team so the CP totem can track who is nearby.
-        // subType: 1 = team-O player, 2 = team-X player (0 = empty auto-reply, ignored).
-        if (sendPresence && ev.rssi >= NEAR_CP_RSSI)
-            out.radio.reply(ev.packet, (uint8_t)(myTeam + 1));
+        // Unicast our presence so the CP totem can track who is nearby.
+        // payload[0]: 1 = team-O player, 2 = team-X player. (The old odd-reply
+        // was silently dropped by the radio's pending-match gate, so CP
+        // ownership never registered.) Presence is RSSI-gated at the CP, so we
+        // are in direct range — no hops needed.
+        if (sendPresence && ev.rssi >= NEAR_CP_RSSI) {
+            uint8_t pl[1] = { (uint8_t)(myTeam + 1) };
+            out.radio.sendTo(ev.packet.senderId, RadioMsg::MSG_CP_NOTIFY, pl, 1);
+        }
     }
 }
 

--- a/src/totem-rulesets/BaseTotem.cpp
+++ b/src/totem-rulesets/BaseTotem.cpp
@@ -8,8 +8,8 @@
 // Lifecycle
 //   onActivate() : starts identity animation; resets beacon timer.
 //   update()     : broadcasts MSG_BASE_BEACON every BASE_BEACON_INTERVAL_MS.
-//   onMessage()  : on player reply (0x57) shows Respawn animation in
-//                  the replying player's team colour.
+//   onMessage()  : on a player's MSG_RESPAWN_NOTIFY unicast shows the
+//                  Respawn animation in the respawning player's colour.
 //   reset()      : clears beacon timer; runner ready for next session.
 //
 // Three singletons share this class: baseO (team 0), baseX (team 1),
@@ -27,6 +27,7 @@
 // ================================================================
 
 using RadioMsg::MSG_BASE_BEACON;
+using RadioMsg::MSG_RESPAWN_NOTIFY;
 
 static constexpr uint32_t BASE_BEACON_INTERVAL_MS = 1000;
 
@@ -56,13 +57,13 @@ public:
     }
 
     void onMessage(const RadioPacket& msg, LightAir_TotemOutput& out) override {
-        // Accept a player's *intentional* respawn reply to our beacon only.
-        // The reply carries subType = team+1 (payload[0] >= 1); the player sends
-        // it solely when it is within its own RSSI proximity gate of this base.
-        // Reject the empty 0x57 auto-reply the GameRunner emits for every beacon
-        // (payloadLen == 0) — it carries no distance information and would make
-        // the base react to any player anywhere in radio range.
-        if (msg.msgType != MSG_BASE_BEACON + 1) return;
+        // Accept a player's *intentional* respawn notification only. The player
+        // unicasts MSG_RESPAWN_NOTIFY to this specific base when it is within
+        // its own RSSI proximity gate; payload[0] = team+1 (>= 1) is a non-zero
+        // sanity marker. Unicast targeting means only the base actually reached
+        // reacts. (The old odd-reply scheme was silently dropped by the radio's
+        // pending-match gate, so this animation never fired.)
+        if (msg.msgType != MSG_RESPAWN_NOTIFY) return;
         if (msg.payloadLen == 0 || msg.payload[0] == 0) return;
         uint8_t r, g, b;
         if (_team == 0xFF) {

--- a/src/totem-rulesets/CPTotem.cpp
+++ b/src/totem-rulesets/CPTotem.cpp
@@ -25,10 +25,12 @@
 //     4. Broadcasts MSG_CP_BEACON with payload[0] = cpTeam (0–15 or 0xFF).
 //     5. Clears presence flags for the next window.
 //
-//   Players reply to MSG_CP_BEACON with subType = myTeam + 1
+//   Players unicast MSG_CP_NOTIFY with payload[0] = myTeam + 1
 //   (1 = team 0/player 1, 2 = team 1/player 2, … 16 = player 16)
 //   when their RSSI to this totem is above their own proximity threshold.
-//   subType 0 (auto empty-reply) is ignored.
+//   (Presence is RSSI-gated at the CP, so the player is in direct range and
+//   a unicast suffices — no hops. The old odd-reply was silently dropped by
+//   the radio's pending-match gate, breaking ownership detection.)
 //
 // Activation
 //   info.roleId = CP.  No additional config needed.
@@ -36,6 +38,7 @@
 
 using RadioMsg::MSG_CP_BEACON;
 using RadioMsg::MSG_CP_SCORE;
+using RadioMsg::MSG_CP_NOTIFY;
 
 static constexpr uint32_t CP_BEACON_INTERVAL_MS = 2000;
 static constexpr uint32_t CP_SCORE_INTERVAL_MS  = 10000;
@@ -75,9 +78,9 @@ public:
     }
 
     void onMessage(const RadioPacket& msg, LightAir_TotemOutput& /*out*/) override {
-        // Collect player presence replies.
-        // subType 1–16 → bit 0–15 in presence mask (subType = team + 1).
-        if (msg.msgType != MSG_CP_BEACON + 1) return;
+        // Collect player presence notifications (unicast MSG_CP_NOTIFY).
+        // payload[0] 1–16 → bit 0–15 in presence mask (= team + 1).
+        if (msg.msgType != MSG_CP_NOTIFY) return;
         if (msg.payloadLen == 0) return;
         uint8_t sub = msg.payload[0];
         if (sub >= 1 && sub <= 16)

--- a/src/totem-rulesets/FlagTotem.cpp
+++ b/src/totem-rulesets/FlagTotem.cpp
@@ -25,13 +25,15 @@
 // The team is fixed at construction and encodes which team's flag this is.
 //
 // Flag protocol (must stay in sync with the Flag ruleset, GameFlag.cpp)
-//   The carrier remembers which flag totem it took and UNICASTS take/drop/
-//   score (MSG_FLAG_NOTIFY) to that one totem.  Because the player emits the
-//   take only within its own RSSI proximity gate of the flag, the totem
-//   inherits that gate; and because it is unicast, only the specific flag the
-//   carrier holds reacts (multiple flags per team work correctly).
-//   MSG_FLAG_EVENT remains a broadcast used by *players* to sync flag-carrier
-//   state and team points — this totem no longer listens to it.
+//   The carrier remembers which flag totem it took and emits take/drop/score
+//   as MSG_FLAG_NOTIFY — a hopped BROADCAST carrying the target flag totem's
+//   id in payload[1].  Drop/score happen away from the flag (the carrier may
+//   be several hops out of the totem's range), so it cannot be a plain
+//   unicast; the broadcast relays across the mesh.  This totem reacts only
+//   when payload[1] == its own id, so the correct flag reacts even with
+//   multiple flags per team and others ignore it.  MSG_FLAG_EVENT remains a
+//   separate broadcast used by *players* to sync flag-carrier state and team
+//   points — this totem no longer listens to it.
 // ================================================================
 
 using RadioMsg::MSG_FLAG_BEACON;
@@ -45,6 +47,7 @@ static constexpr uint8_t  FLAG_STATE_OUT = 1;
 class FlagTotem : public LightAir_TotemRunner {
     const uint8_t _team;        // 0=O, 1=X; fixed at construction
     uint8_t       _state;       // FLAG_STATE_IN or FLAG_STATE_OUT
+    uint8_t       _selfId;      // this totem's own id; matches MSG_FLAG_NOTIFY target
     uint32_t      _lastBeacon;
 
     void teamColor(uint8_t& r, uint8_t& g, uint8_t& b) const {
@@ -72,24 +75,27 @@ class FlagTotem : public LightAir_TotemRunner {
 
 public:
     explicit FlagTotem(uint8_t team)
-        : _team(team), _state(FLAG_STATE_IN), _lastBeacon(0) {}
+        : _team(team), _state(FLAG_STATE_IN), _selfId(0xFF), _lastBeacon(0) {}
 
-    void onActivate(const LightAir_TotemActivation& /*info*/,
+    void onActivate(const LightAir_TotemActivation& info,
                     LightAir_TotemOutput& out) override {
         _state      = FLAG_STATE_IN;
+        _selfId     = info.selfId;
         _lastBeacon = 0;
         showIdle(out);
     }
 
     void onMessage(const RadioPacket& msg, LightAir_TotemOutput& out) override {
-        // This totem is driven by MSG_FLAG_NOTIFY unicasts addressed to it
-        // specifically: the carrier remembers which flag totem it took and
-        // unicasts take/drop/score to that one totem. Unicast targeting means
-        // no team filter is needed (only the right totem receives it), and
-        // multiple flags per team work correctly. payload[0] = FlagEvent sub.
+        // This totem is driven by MSG_FLAG_NOTIFY: a hopped broadcast the
+        // carrier emits on take/drop/score, addressed to one flag totem by id
+        // in payload[1]. We react only when payload[1] == our own id, so the
+        // right flag reacts even with multiple flags per team, and the message
+        // can still reach us across relays when the carrier is out of direct
+        // range (drop/score happen away from the flag). payload[0] = sub-type.
         // (MSG_FLAG_EVENT remains a broadcast for player-to-player state sync.)
         if (msg.msgType != MSG_FLAG_NOTIFY) return;
-        if (msg.payloadLen < 1)             return;
+        if (msg.payloadLen < 2)             return;
+        if (msg.payload[1] != _selfId)      return;  // not addressed to this flag
 
         const uint8_t sub = msg.payload[0];
 

--- a/src/totem-rulesets/FlagTotem.cpp
+++ b/src/totem-rulesets/FlagTotem.cpp
@@ -13,8 +13,8 @@
 //   onActivate() : enters FLAG_IN; shows Idle background (team colour glow).
 //   update()     : in FLAG_IN, broadcasts MSG_FLAG_BEACON every
 //                  FLAG_BEACON_INTERVAL_MS.
-//   onMessage()  : driven entirely by MSG_FLAG_EVENT broadcasts from players
-//                  (payload[1] == _team selects events for this flag):
+//   onMessage()  : driven by MSG_FLAG_NOTIFY unicasts addressed to this
+//                  totem (payload[0] = FlagEvent sub-type):
 //     FlagEvent::TAKEN   — FLAG_IN → FLAG_OUT + FlagMissing anim (team colour)
 //                          + FlagTaken flash (picker's colour).
 //     FlagEvent::DROPPED — FLAG_OUT → FLAG_IN + FlagReturn anim (flash).
@@ -25,16 +25,17 @@
 // The team is fixed at construction and encodes which team's flag this is.
 //
 // Flag protocol (must stay in sync with the Flag ruleset, GameFlag.cpp)
-//   The totem reacts only to MSG_FLAG_EVENT broadcasts a player emits when it
-//   actually picks up, scores, or drops a flag — and the player emits those
-//   only once it is within its own RSSI proximity gate of the flag/base.  The
-//   totem therefore inherits that proximity gate and never reacts to a distant
-//   player.  (It must NOT react to the empty 0x59 auto-reply the GameRunner
-//   sends for every beacon, which carries no distance information.)
+//   The carrier remembers which flag totem it took and UNICASTS take/drop/
+//   score (MSG_FLAG_NOTIFY) to that one totem.  Because the player emits the
+//   take only within its own RSSI proximity gate of the flag, the totem
+//   inherits that gate; and because it is unicast, only the specific flag the
+//   carrier holds reacts (multiple flags per team work correctly).
+//   MSG_FLAG_EVENT remains a broadcast used by *players* to sync flag-carrier
+//   state and team points — this totem no longer listens to it.
 // ================================================================
 
 using RadioMsg::MSG_FLAG_BEACON;
-using RadioMsg::MSG_FLAG_EVENT;
+using RadioMsg::MSG_FLAG_NOTIFY;
 namespace FE = FlagEvent;
 
 static constexpr uint32_t FLAG_BEACON_INTERVAL_MS = 500;
@@ -81,12 +82,14 @@ public:
     }
 
     void onMessage(const RadioPacket& msg, LightAir_TotemOutput& out) override {
-        // Only MSG_FLAG_EVENT broadcasts drive this totem; payload[1] selects
-        // events for the flag this totem owns.  Player-side RSSI gating means
-        // these only fire when a player is actually at the flag/base.
-        if (msg.msgType != MSG_FLAG_EVENT) return;
-        if (msg.payloadLen < 2)            return;
-        if (msg.payload[1] != _team)       return;  // not our flag's event
+        // This totem is driven by MSG_FLAG_NOTIFY unicasts addressed to it
+        // specifically: the carrier remembers which flag totem it took and
+        // unicasts take/drop/score to that one totem. Unicast targeting means
+        // no team filter is needed (only the right totem receives it), and
+        // multiple flags per team work correctly. payload[0] = FlagEvent sub.
+        // (MSG_FLAG_EVENT remains a broadcast for player-to-player state sync.)
+        if (msg.msgType != MSG_FLAG_NOTIFY) return;
+        if (msg.payloadLen < 1)             return;
 
         const uint8_t sub = msg.payload[0];
 

--- a/src/totem-rulesets/FlagTotem.cpp
+++ b/src/totem-rulesets/FlagTotem.cpp
@@ -13,8 +13,8 @@
 //   onActivate() : enters FLAG_IN; shows Idle background (team colour glow).
 //   update()     : in FLAG_IN, broadcasts MSG_FLAG_BEACON every
 //                  FLAG_BEACON_INTERVAL_MS.
-//   onMessage()  : driven by MSG_FLAG_NOTIFY unicasts addressed to this
-//                  totem (payload[0] = FlagEvent sub-type):
+//   onMessage()  : driven by MSG_FLAG_EVENT broadcasts addressed to this
+//                  totem via payload[2] (payload[0] = FlagEvent sub-type):
 //     FlagEvent::TAKEN   — FLAG_IN → FLAG_OUT + FlagMissing anim (team colour)
 //                          + FlagTaken flash (picker's colour).
 //     FlagEvent::DROPPED — FLAG_OUT → FLAG_IN + FlagReturn anim (flash).
@@ -25,19 +25,18 @@
 // The team is fixed at construction and encodes which team's flag this is.
 //
 // Flag protocol (must stay in sync with the Flag ruleset, GameFlag.cpp)
-//   The carrier remembers which flag totem it took and emits take/drop/score
-//   as MSG_FLAG_NOTIFY — a hopped BROADCAST carrying the target flag totem's
-//   id in payload[1].  Drop/score happen away from the flag (the carrier may
-//   be several hops out of the totem's range), so it cannot be a plain
-//   unicast; the broadcast relays across the mesh.  This totem reacts only
-//   when payload[1] == its own id, so the correct flag reacts even with
-//   multiple flags per team and others ignore it.  MSG_FLAG_EVENT remains a
-//   separate broadcast used by *players* to sync flag-carrier state and team
-//   points — this totem no longer listens to it.
+//   A single flooded MSG_FLAG_EVENT broadcast per event does both jobs:
+//   players read payload[0]/[1] to sync carrier state and team points, while
+//   payload[2] carries the target flag totem's id (the carrier remembers it
+//   from the beacon it took).  This totem animates only when payload[2] ==
+//   its own id, so the correct flag reacts even with multiple flags per team
+//   and others ignore it.  Drop/score happen away from the flag (the carrier
+//   may be several hops out of range), so the broadcast relays across the
+//   mesh to reach it — a plain unicast could not.
 // ================================================================
 
 using RadioMsg::MSG_FLAG_BEACON;
-using RadioMsg::MSG_FLAG_NOTIFY;
+using RadioMsg::MSG_FLAG_EVENT;
 namespace FE = FlagEvent;
 
 static constexpr uint32_t FLAG_BEACON_INTERVAL_MS = 500;
@@ -47,7 +46,7 @@ static constexpr uint8_t  FLAG_STATE_OUT = 1;
 class FlagTotem : public LightAir_TotemRunner {
     const uint8_t _team;        // 0=O, 1=X; fixed at construction
     uint8_t       _state;       // FLAG_STATE_IN or FLAG_STATE_OUT
-    uint8_t       _selfId;      // this totem's own id; matches MSG_FLAG_NOTIFY target
+    uint8_t       _selfId;      // this totem's own id; matches MSG_FLAG_EVENT payload[2]
     uint32_t      _lastBeacon;
 
     void teamColor(uint8_t& r, uint8_t& g, uint8_t& b) const {
@@ -86,16 +85,14 @@ public:
     }
 
     void onMessage(const RadioPacket& msg, LightAir_TotemOutput& out) override {
-        // This totem is driven by MSG_FLAG_NOTIFY: a hopped broadcast the
-        // carrier emits on take/drop/score, addressed to one flag totem by id
-        // in payload[1]. We react only when payload[1] == our own id, so the
-        // right flag reacts even with multiple flags per team, and the message
-        // can still reach us across relays when the carrier is out of direct
-        // range (drop/score happen away from the flag). payload[0] = sub-type.
-        // (MSG_FLAG_EVENT remains a broadcast for player-to-player state sync.)
-        if (msg.msgType != MSG_FLAG_NOTIFY) return;
-        if (msg.payloadLen < 2)             return;
-        if (msg.payload[1] != _selfId)      return;  // not addressed to this flag
+        // Driven by MSG_FLAG_EVENT — the same flooded broadcast players use to
+        // sync carrier state. payload[2] = target flag totem id: we animate
+        // only when it == our own id, so the right flag reacts (multiple flags
+        // per team work) and the hopped broadcast still reaches us when the
+        // carrier drops/scores out of our direct range. payload[0] = sub-type.
+        if (msg.msgType != MSG_FLAG_EVENT) return;
+        if (msg.payloadLen < 3)            return;
+        if (msg.payload[2] != _selfId)     return;  // not addressed to this flag
 
         const uint8_t sub = msg.payload[0];
 

--- a/src/totem/LightAir_TotemDriver.cpp
+++ b/src/totem/LightAir_TotemDriver.cpp
@@ -73,6 +73,7 @@ void LightAir_TotemDriver::loop() {
                                              ev.packet.payload[3];
                     info.hasConfigSecs    = ev.packet.payloadLen >= 5;
                     info.configSecs       = info.hasConfigSecs ? ev.packet.payload[4] : 0;
+                    info.selfId           = _radio.playerId();
 
                     _runner = role->runner;
                     _radio.setTypeId(incomingTypeId);

--- a/src/totem/LightAir_TotemRunner.h
+++ b/src/totem/LightAir_TotemRunner.h
@@ -64,6 +64,8 @@ struct LightAir_TotemActivation {
     uint16_t gameTimeLeftSecs;   // 0xFFFF = unknown / no watchdog budget
     bool     hasConfigSecs;
     uint8_t  configSecs;        // valid only if hasConfigSecs
+    uint8_t  selfId;            // this totem's own logical id (= its beacon senderId);
+                                //   lets a runner match notifies addressed to it by id
 };
 
 class LightAir_TotemRunner {


### PR DESCRIPTION
- Make pre-start config delivery and accept count robust to packet loss
- Drive Base/Flag totem animations via player→totem unicast
- Flag notify via hopped broadcast; fix CP presence drop the same way
- Fold flag totem notify into MSG_FLAG_EVENT (one flood per event)